### PR TITLE
push時にsuper-linterが走らないようにする

### DIFF
--- a/.github/workflows/push-lint.yml
+++ b/.github/workflows/push-lint.yml
@@ -14,7 +14,6 @@ name: push-code
 # Start the job on all push #
 #############################
 on:
-  push:
   pull_request:
 
 ###############


### PR DESCRIPTION
現状ではPRを投げるとsuper-linterが二重に走ってしまうため、push時にはsuper-linterが走らないようにします。