### PR TITLE
DB待機用スクリプト追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ COPY . .
 RUN pip install pipenv==2020.6.2 --no-cache-dir && \
     pipenv install
 
-CMD ["sh", "./entrypoint.sh"]
+CMD ["bash", "./entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e -o pipefail
+
 # PostgreSQLの起動を待機する
 pipenv run python wait_db.py
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,11 +1,7 @@
 #!/bin/sh
 
 # PostgreSQLの起動を待機する
-RETRIES=10
-until psql $DATABASE_URL -c "select 1" > /dev/null 2>&1 || [ $RETRIES -eq 0 ]; do
-  echo "Waiting for postgres server, $((RETRIES-=1)) remaining attempts..."
-  sleep 1
-done
+pipenv run python wait_db.py
 
 pipenv run python create_env.py
 

--- a/library/database.py
+++ b/library/database.py
@@ -13,8 +13,9 @@ class Database:
     def __init__(self):
         try:
             self.conn = psycopg2.connect(conf.DB_URL, sslmode='require')
-        except psycopg2.Error:
+        except psycopg2.Error as e:
             print('Can not connect to database.')
+            raise e
 
     def __enter__(self):
         return self

--- a/library/database.py
+++ b/library/database.py
@@ -13,9 +13,9 @@ class Database:
     def __init__(self):
         try:
             self.conn = psycopg2.connect(conf.DB_URL, sslmode='require')
-        except psycopg2.Error as e:
+        except psycopg2.Error as _e:
             print('Can not connect to database.')
-            raise e
+            raise _e
 
     def __enter__(self):
         return self

--- a/wait_db.py
+++ b/wait_db.py
@@ -15,15 +15,14 @@ def wait_db() -> None:
 
     for i in range(max_attempt):
         try:
-            with Database() as db:
-                db.execute_sql('SELECT 1')
+            with Database() as _db:
+                _db.execute_sql('SELECT 1')
                 break
-        except psycopg2.OperationalError as e:
+        except psycopg2.OperationalError as _e:
             if i == max_attempt - 1:
-                raise e
+                raise _e
 
             sleep(1)
-            pass
 
     print('postgres is running!')
 

--- a/wait_db.py
+++ b/wait_db.py
@@ -11,12 +11,17 @@ from library.database import Database
 def wait_db() -> None:
     """DBが起動するまで待機する"""
 
-    while True:
+    max_attempt = 10
+
+    for i in range(max_attempt):
         try:
             with Database() as db:
                 db.execute_sql('SELECT 1')
                 break
-        except psycopg2.OperationalError:
+        except psycopg2.OperationalError as e:
+            if i == max_attempt - 1:
+                raise e
+
             sleep(1)
             pass
 

--- a/wait_db.py
+++ b/wait_db.py
@@ -1,0 +1,33 @@
+"""
+DBが起動するまで待機する
+"""
+from time import sleep
+
+import psycopg2
+
+from library.database import Database
+
+
+def wait_db() -> None:
+    """DBが起動するまで待機する"""
+
+    while True:
+        try:
+            with Database() as db:
+                db.execute_sql('SELECT 1')
+                break
+        except psycopg2.OperationalError:
+            sleep(1)
+            pass
+
+    print('postgres is running!')
+
+
+def main():
+    """メイン関数"""
+
+    wait_db()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
これまではDBが起動するまで待機する処理を `entrypoint.sh` 内で行なっていましたが、postgresqlクライアントがインストールされていなかったことから正常に動作していませんでした。
したがって、この部分の処理をPythonで行うよう変更します。