### PR TITLE
ameshを取得する際のパラメータをrequestsの引数として与える

### DIFF
--- a/plugins/hato.py
+++ b/plugins/hato.py
@@ -162,7 +162,7 @@ def amesh(place: str):
                                'lon': lon,
                                'z': '12',
                                'height': '640',
-                               'weight': '800',
+                               'width': '800',
                                'overlay': 'type:rainfall|datelabel:off'
                            },
                            stream=True)

--- a/plugins/hato.py
+++ b/plugins/hato.py
@@ -130,14 +130,6 @@ def totuzensi(message: str):
     return ret
 
 
-def weather_map_url(appid: str, lat: str, lon: str) -> str:
-    """weather_map_urlを作る"""
-    return (
-        'https://map.yahooapis.jp/map/V1/static?' +
-        'appid={}&lat={}&lon={}&z=12&height=640&width=800&overlay=type:rainfall|datelabel:off'
-    ).format(appid, lat, lon)
-
-
 def amesh(place: str):
     """天気を表示する"""
 
@@ -163,8 +155,17 @@ def amesh(place: str):
             return None
 
         client.post(msg)
-        url = weather_map_url(conf.YAHOO_API_TOKEN, lat, lon)
-        req = requests.get(url, stream=True)
+        req = requests.get('https://map.yahooapis.jp/map/V1/static',
+                           {
+                               'appid': conf.YAHOO_API_TOKEN,
+                               'lat': lat,
+                               'lon': lon,
+                               'z': '12',
+                               'height': '640',
+                               'weight': '800',
+                               'overlay': 'type:rainfall|datelabel:off'
+                           },
+                           stream=True)
         if req.status_code == 200:
             with NamedTemporaryFile() as weather_map_file:
                 weather_map_file.write(req.content)

--- a/tests/plugins/test_hato.py
+++ b/tests/plugins/test_hato.py
@@ -76,7 +76,10 @@ class TestAmesh(unittest.TestCase):
             'overlay': 'type:rainfall|datelabel:off'
         }
         query = '&'.join([f'{k}={v}' for k, v in params.items()])
-        mocker.get('https://map.yahooapis.jp/map/V1/static?' + query, content=content)
+        mocker.get(
+            'https://map.yahooapis.jp/map/V1/static?' + query,
+            content=content
+        )
         req = amesh(place)(client1)
         self.assertEqual(req.status_code, 200)
         return client1

--- a/tests/plugins/test_hato.py
+++ b/tests/plugins/test_hato.py
@@ -8,7 +8,7 @@ from typing import List
 import requests_mock
 
 import slackbot_settings as conf
-from plugins.hato import split_command, amesh, weather_map_url
+from plugins.hato import split_command, amesh
 from tests.library.test_amesh import set_mock
 from tests.plugins import TestClient
 
@@ -66,9 +66,17 @@ class TestAmesh(unittest.TestCase):
         :param content: req.contentで返すデータ
         """
         client1 = TestClient()
-        mocker.get(weather_map_url(conf.YAHOO_API_TOKEN,
-                                   *coordinate),
-                   content=content)
+        params = {
+            'appid': conf.YAHOO_API_TOKEN,
+            'lat': coordinate[0],
+            'lon': coordinate[1],
+            'z': 12,
+            'height': 640,
+            'weight': 800,
+            'overlay': 'type:rainfall|datelabel:off'
+        }
+        query = '&'.join([f'{k}={v}' for k, v in params.items()])
+        mocker.get('https://map.yahooapis.jp/map/V1/static?' + query, content=content)
         req = amesh(place)(client1)
         self.assertEqual(req.status_code, 200)
         return client1
@@ -136,19 +144,6 @@ class TestAmesh(unittest.TestCase):
                                           coordinate)
             self.assertEqual(client1.get_post_message(), '雨雲状況をお知らせするっぽ！')
             self.assertEqual(client1.get_filename(), 'amesh')
-
-    def test_weather_map_url(self):
-        """
-        weather_map_urlを正しく作れるかテスト
-        """
-        appid = 'hoge'
-        lat = '35.698856'
-        lon = '139.73091159273'
-        url = (
-            'https://map.yahooapis.jp/map/V1/static?' +
-            'appid={}&lat={}&lon={}&z=12&height=640&width=800&overlay=type:rainfall|datelabel:off'
-        ).format(appid, lat, lon)
-        self.assertEqual(weather_map_url(appid, lat, lon), url)
 
 
 if __name__ == '__main__':

--- a/tests/plugins/test_hato.py
+++ b/tests/plugins/test_hato.py
@@ -72,7 +72,7 @@ class TestAmesh(unittest.TestCase):
             'lon': coordinate[1],
             'z': 12,
             'height': 640,
-            'weight': 800,
+            'width': 800,
             'overlay': 'type:rainfall|datelabel:off'
         }
         query = '&'.join([f'{k}={v}' for k, v in params.items()])


### PR DESCRIPTION
ameshを取得する際、パラメータを入れたURLを組み立て、それをrequestsに渡しています。
https://github.com/dev-hato/hato-bot/blob/5feb8fe50684b21950be5eba588d7067b738a0e6/plugins/hato.py#L178-L183
https://github.com/dev-hato/hato-bot/blob/5feb8fe50684b21950be5eba588d7067b738a0e6/plugins/hato.py#L202-L203

しかし、これだとパラメータを追加しづらかったり可読性がよくなかったりするので、`requests.get` の第二引数 ( `params` ) にパラメータを渡す形式に変更します。