### PR TITLE
.dockerignore追加

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore


### PR DESCRIPTION
Dockerビルド時に `Pipfile.lock` 等の不要なファイルがCOPYされてビルドに失敗しないよう、 `.dockerignore` を追加します。
一旦 `.gitignore` へのシンボリックリンクとしています。