### PR TITLE
localからコマンドを投げた際に、投げたコマンドも投稿されるようにする

### DIFF
--- a/run.py
+++ b/run.py
@@ -83,7 +83,9 @@ def http_app():
     msg = request.json['message']
     channel = request.json['channel']
     user = request.json['user']
-    analyze.analyze_message(msg)(SlackClient(channel, user))
+    client = SlackClient(channel, user)
+    client.post(f'コマンド: {msg}')
+    analyze.analyze_message(msg)(client)
     return "success"
 
 


### PR DESCRIPTION
hato-botに対して以下のようなリクエストを投げることで、メンションを投げた際と同じ動作を行わせることが可能です。

```sh
$ curl -XPOST -d '{"message": "amesh", "channel": "C0189D2B8F7", "user": "U018B02SXFD"}'         -H "Content-Type: application/json" http://0.0.0.0:3000/
```

しかし、この方式だとSlackに投稿されたメッセージがどういったコマンドによるものかがわかりません。
したがって、以下のような形で実行したコマンドも投稿されるようにします。

```
hato
コマンド: text list
登録されている単語はないっぽ！
```