### PR TITLE
sudden_deathのignore_missing_imports削除

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -10,8 +10,5 @@ ignore_missing_imports = True
 [mypy-pyperclip.*]
 ignore_missing_imports = True
 
-[mypy-sudden_death.*]
-ignore_missing_imports = True
-
 [mypy-requests_mock.*]
 ignore_missing_imports = True


### PR DESCRIPTION
https://github.com/dev-hato/sudden-death/pull/15 がマージされた場合、sudden_deathにignore_missing_importsを設定する必要がなくなるため、設定を削除します。