### PR TITLE
PRクローズ時にbaseを引数に取らないようにする

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -109,14 +109,11 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo
             }
-            const pull_params = {
-              base: "${{github.event.pull_request.head.ref}}",
-              ...common_params
-            }
             const pulls_list_params = {
               head: "refs/" + ref,
+              base: "${{github.event.pull_request.head.ref}}",
               state: "open",
-              ...pull_params
+              ...common_params
             }
             console.log("call pulls.list:")
             console.log(pulls_list_params)
@@ -126,7 +123,7 @@ jobs:
                   const pulls_update_params = {
                     pull_number: data.number,
                     state: "closed",
-                    ...pull_params
+                    ...common_params
                   }
                   console.log("call pulls.update:")
                   console.log(pulls_update_params)


### PR DESCRIPTION
ref. https://github.com/dev-hato/sudden-death/pull/20

`pulls.update` にbaseを引数として与えると、baseを変えることになってしまい、PRをクローズするのと矛盾が生じてしまうため、baseを引数として与えないようにします。