### PR TITLE
pr-testをpush時にも発動するようにする

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1,8 +1,9 @@
 name: pr-test
 
-# pull_requestで何かあった時に起動する
+# pull_requestで何かあったり、pushされたりした時に起動する
 on:
   pull_request:
+  push:
 
 env:
   WORKON_HOME: /tmp/.venv


### PR DESCRIPTION
手動でpushし、それを使ってGitHub ActionsがPRを作った場合、 `pr-test` が発動しないので、pushした場合にも `pr-test` が発動するようにします。

ref: https://docs.github.com/ja/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token