### PR TITLE
PR一覧取得時のheadとbaseの指定方法修正

### DIFF
--- a/.github/workflows/pr-copy-ci-hato-bot.yml
+++ b/.github/workflows/pr-copy-ci-hato-bot.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          repository: ${{github.event.pull_request.head.repo.owner.login}}/sudden-death
+          repository: dev-hato/sudden-death
           path: sudden-death
       - name: Copy CI
         run: |
@@ -42,4 +42,5 @@ jobs:
           git commit -m "鳩は唐揚げ！(hato-botのCIを反映するよ！)"
           echo "${{secrets.SUDDEN_DEATH_CI_PRIVATE_KEY}}" > deploy_key.pem
           chmod 600 deploy_key.pem
-          GIT_SSH_COMMAND="ssh -i deploy_key.pem -o StrictHostKeyChecking=no -F /dev/null" git push -f "git@github.com:${{github.event.pull_request.head.repo.owner.login}}/sudden-death.git" HEAD:refs/heads/pr-copy-ci
+          GIT_SSH_COMMAND="ssh -i deploy_key.pem -o StrictHostKeyChecking=no -F /dev/null" git push -f "git@github.com:dev-hato/sudden-death.git" HEAD:refs/heads/pr-copy-ci
+          

--- a/.github/workflows/pr-copy-ci-hato-bot.yml
+++ b/.github/workflows/pr-copy-ci-hato-bot.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          repository: dev-hato/sudden-death
+          repository: ${{github.event.pull_request.head.repo.owner.login}}/sudden-death
           path: sudden-death
       - name: Copy CI
         run: |
@@ -42,5 +42,4 @@ jobs:
           git commit -m "鳩は唐揚げ！(hato-botのCIを反映するよ！)"
           echo "${{secrets.SUDDEN_DEATH_CI_PRIVATE_KEY}}" > deploy_key.pem
           chmod 600 deploy_key.pem
-          GIT_SSH_COMMAND="ssh -i deploy_key.pem -o StrictHostKeyChecking=no -F /dev/null" git push -f "git@github.com:dev-hato/sudden-death.git" HEAD:refs/heads/pr-copy-ci
-          
+          GIT_SSH_COMMAND="ssh -i deploy_key.pem -o StrictHostKeyChecking=no -F /dev/null" git push -f "git@github.com:${{github.event.pull_request.head.repo.owner.login}}/sudden-death.git" HEAD:refs/heads/pr-copy-ci

--- a/.github/workflows/pr-release-hato-bot.yml
+++ b/.github/workflows/pr-release-hato-bot.yml
@@ -36,8 +36,8 @@ jobs:
               repo: context.repo.repo
             }
             const pull_params = {
-              head: "develop",
-              base: "refs/heads/master",
+              head: "dev-hato:develop",
+              base: "master",
               ...common_params
             }
             const pulls_list_params = {
@@ -47,7 +47,7 @@ jobs:
             console.log("call pulls.list:")
             console.log(pulls_list_params)
             github.pulls.list(pulls_list_params).then(list_res => {
-              if (list_res.data.filter(data => data.user.id === 41898282).length === 0) {
+              if (list_res.data.length === 0) {
                 const pulls_create_params = {
                   title: "リリース",
                   body: "鳩は唐揚げになるため、片栗粉へ飛び込む",

--- a/.github/workflows/pr-release-hato-bot.yml
+++ b/.github/workflows/pr-release-hato-bot.yml
@@ -36,7 +36,7 @@ jobs:
               repo: context.repo.repo
             }
             const pull_params = {
-              head: "dev-hato:develop",
+              head: "${{github.event.pull_request.head.repo.owner.login}}:develop",
               base: "master",
               ...common_params
             }

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -73,7 +73,7 @@ jobs:
               repo: context.repo.repo
             }
             const pull_params = {
-              head: "refs/heads/fix-format-${{github.event.pull_request.head.ref}}",
+              head: "dev-hato:fix-format-${{github.event.pull_request.head.ref}}",
               base: "${{github.event.pull_request.head.ref}}",
               ...common_params
             }
@@ -84,7 +84,7 @@ jobs:
             console.log("call pulls.list:")
             console.log(pulls_list_params)
             github.pulls.list(pulls_list_params).then(list_res => {
-              if (list_res.data.filter(data => data.user.id === 41898282).length === 0) {
+              if (list_res.data.length === 0) {
                 const pulls_create_params = {
                   title: "formatが間違ってたので直してあげたよ！PRをマージしてね！ #${{github.event.pull_request.number}}",
                   body: "鳩の唐揚げおいしい！😋😋😋 #${{github.event.pull_request.number}}",
@@ -111,13 +111,13 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const ref = "heads/fix-format-${{github.event.pull_request.head.ref}}"
+            const head_name = "fix-format-${{github.event.pull_request.head.ref}}"
             const common_params = {
               owner: context.repo.owner,
               repo: context.repo.repo
             }
             const pulls_list_params = {
-              head: "refs/" + ref,
+              head: "dev-hato:" + head_name,
               base: "${{github.event.pull_request.head.ref}}",
               state: "open",
               ...common_params
@@ -126,24 +126,22 @@ jobs:
             console.log(pulls_list_params)
             github.pulls.list(pulls_list_params).then(res => {
               for(const data of res.data){
-                if(data.user.id === 41898282) {
-                  const pulls_update_params = {
-                    pull_number: data.number,
-                    state: "closed",
+                const pulls_update_params = {
+                  pull_number: data.number,
+                  state: "closed",
+                  ...common_params
+                }
+                console.log("call pulls.update:")
+                console.log(pulls_update_params)
+                github.pulls.update(pulls_update_params).then(res2 => {
+                  const git_deleteRef_params = {
+                    ref: "heads/" + head_name,
                     ...common_params
                   }
-                  console.log("call pulls.update:")
-                  console.log(pulls_update_params)
-                  github.pulls.update(pulls_update_params).then(res2 => {
-                    const git_deleteRef_params = {
-                      ref: ref,
-                      ...common_params
-                    }
-                    console.log("call git.deleteRef:")
-                    console.log(git_deleteRef_params)
-                    github.git.deleteRef(git_deleteRef_params)
-                  })
-                }
+                  console.log("call git.deleteRef:")
+                  console.log(git_deleteRef_params)
+                  github.git.deleteRef(git_deleteRef_params)
+                })
               }
             })
       - name: Exit

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -73,7 +73,7 @@ jobs:
               repo: context.repo.repo
             }
             const pull_params = {
-              head: "dev-hato:fix-format-${{github.event.pull_request.head.ref}}",
+              head: "${{github.event.pull_request.head.repo.owner.login}}:fix-format-${{github.event.pull_request.head.ref}}",
               base: "${{github.event.pull_request.head.ref}}",
               ...common_params
             }
@@ -117,7 +117,7 @@ jobs:
               repo: context.repo.repo
             }
             const pulls_list_params = {
-              head: "dev-hato:" + head_name,
+              head: "${{github.event.pull_request.head.repo.owner.login}}:" + head_name,
               base: "${{github.event.pull_request.head.ref}}",
               state: "open",
               ...common_params


### PR DESCRIPTION
`github.pulls.list` に対し、headを `organization-name:branch-name` 形式で与え、baseを `branch-name` 形式で与えるのが正しいので修正します。

headを `organization-name:branch-name` 形式で与えた場合: https://github.com/dev-hato/hato-bot/pull/336/checks?check_run_id=1076707549
headを `ref/heads/branch-name` 形式で与えた場合: https://github.com/dev-hato/hato-bot/pull/337/checks?check_run_id=1076708514
ref: https://developer.github.com/v3/pulls/#list-pull-requests