### PR TITLE
organization nameを固定値にする

### DIFF
--- a/.github/workflows/pr-release-hato-bot.yml
+++ b/.github/workflows/pr-release-hato-bot.yml
@@ -36,7 +36,7 @@ jobs:
               repo: context.repo.repo
             }
             const pull_params = {
-              head: "${{github.event.pull_request.head.repo.owner.login}}:develop",
+              head: "dev-hato:develop",
               base: "master",
               ...common_params
             }

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -73,7 +73,7 @@ jobs:
               repo: context.repo.repo
             }
             const pull_params = {
-              head: "${{github.event.pull_request.head.repo.owner.login}}:fix-format-${{github.event.pull_request.head.ref}}",
+              head: "dev-hato:fix-format-${{github.event.pull_request.head.ref}}",
               base: "${{github.event.pull_request.head.ref}}",
               ...common_params
             }
@@ -117,7 +117,7 @@ jobs:
               repo: context.repo.repo
             }
             const pulls_list_params = {
-              head: "${{github.event.pull_request.head.repo.owner.login}}:" + head_name,
+              head: "dev-hato:" + head_name,
               base: "${{github.event.pull_request.head.ref}}",
               state: "open",
               ...common_params


### PR DESCRIPTION
`github.event.pull_request.head.repo.owner.login` はpushの場合取得できないので、一旦固定値にします。