### PR TITLE
cpの方が都合がよさそう

### DIFF
--- a/.github/workflows/pr-test-hato-bot.yml
+++ b/.github/workflows/pr-test-hato-bot.yml
@@ -26,8 +26,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install pipenv
         run: curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python
-      - name: pipfile mv
-        run: mv Pipfile.lock-${{ matrix.python-version }} Pipfile.lock
+      - name: pipfile cp
+        run: cp Pipfile.lock-${{ matrix.python-version }} Pipfile.lock
       - name: pipenv cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -27,8 +27,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install pipenv
         run: curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python
-      - name: pipfile mv
-        run: mv Pipfile.lock-${{ matrix.python-version }} Pipfile.lock
+      - name: pipfile cp
+        run: cp Pipfile.lock-${{ matrix.python-version }} Pipfile.lock
       - name: pipenv cache
         uses: actions/cache@v2
         with:
@@ -165,8 +165,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install pipenv
         run: curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python
-      - name: pipfile mv
-        run: mv Pipfile.lock-${{ matrix.python-version }} Pipfile.lock
+      - name: pipfile cp
+        run: cp Pipfile.lock-${{ matrix.python-version }} Pipfile.lock
       - name: pipenv cache
         uses: actions/cache@v2
         with:
@@ -201,8 +201,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install pipenv
         run: curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python
-      - name: pipfile mv
-        run: mv Pipfile.lock-${{ matrix.python-version }} Pipfile.lock
+      - name: pipfile cp
+        run: cp Pipfile.lock-${{ matrix.python-version }} Pipfile.lock
       - name: pipenv cache
         uses: actions/cache@v2
         with:
@@ -290,8 +290,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install pipenv
         run: curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python
-      - name: pipfile mv
-        run: mv Pipfile.lock-${{ matrix.python-version }} Pipfile.lock
+      - name: pipfile cp
+        run: cp Pipfile.lock-${{ matrix.python-version }} Pipfile.lock
       - name: pipenv cache
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
pr-formatの時に、Pipfile.lock-3.8が消えてしまうPRが出されてしまう