### PR TITLE
Reduce docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
+# バージョン情報に表示する commit hash を埋め込む
 FROM alpine AS commit-hash
 COPY .git .
+COPY slackbot_settings.py .
 RUN apk add -U git
-RUN echo "GIT_COMMIT_HASH=$(git rev-parse HEAD)" >> .env
+RUN sed -i "s/^\(GIT_COMMIT_HASH = \).*\$/\1'$(git rev-parse HEAD)'/" slackbot_settings.py
 
 FROM python:3.8.5-alpine
 
@@ -24,7 +26,7 @@ RUN apk add --no-cache -t .used-packages postgresql-libs=12.4-r0 && \
     pipenv install --system && \
     apk --purge del .build-deps
 
-COPY --from=commit-hash .env .
-COPY *.py library plugins .
+COPY *.py library plugins ./
+COPY --from=commit-hash slackbot_settings.py slackbot_settings.py
 
 CMD ["python", "entrypoint.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,8 @@
+FROM alpine AS commit-hash
+COPY .git .
+RUN apk add -U git
+RUN echo "GIT_COMMIT_HASH=$(git rev-parse HEAD)" >> .env
+
 FROM python:3.8.5-alpine
 
 ENV WORKON_HOME=/usr/src/venv
@@ -9,17 +14,17 @@ COPY Pipfile.lock-3.8 Pipfile.lock
 
 # 実行時に必要なパッケージ (グループ名: .used-packages)
 # * postgresql-libs: psycopg2を使用する際に必要
-# * git: Pythonライブラリのインストールとバージョン表示の際に必要
 #
 # Pythonライブラリのインストール時に必要なパッケージ (グループ名: .build-deps, Pythonライブラリインストール後にアンインストール)
 # * jpeg-dev, zlib-dev: Pillowのインストールの際に必要
 # * gcc, musl-dev, postgresql-dev: psycopg2のインストールの際に必要
-RUN apk add --no-cache -t .used-packages postgresql-libs=12.4-r0 git=2.26.2-r0 && \
-    apk add --no-cache -t .build-deps jpeg-dev=9d-r0 zlib-dev=1.2.11-r3 gcc=9.3.0-r2 musl-dev=1.1.24-r9 postgresql-dev=12.4-r0 && \
+RUN apk add --no-cache -t .used-packages postgresql-libs=12.4-r0 && \
+    apk add --no-cache -t .build-deps jpeg-dev=9d-r0 zlib-dev=1.2.11-r3 gcc=9.3.0-r2 musl-dev=1.1.24-r9 postgresql-dev=12.4-r0 git=2.26.2-r0 && \
     pip install pipenv==2020.6.2 --no-cache-dir && \
-    pipenv install && \
+    pipenv install --system && \
     apk --purge del .build-deps
 
-COPY . .
+COPY --from=commit-hash .env .
+COPY *.py library plugins .
 
-CMD ["pipenv", "run", "python", "entrypoint.py"]
+CMD ["python", "entrypoint.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,5 @@ COPY library library
 COPY plugins plugins
 COPY --from=commit-hash slackbot_settings.py slackbot_settings.py
 
+ENV GIT_PYTHON_REFRESH=quiet
 CMD ["python", "entrypoint.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 # バージョン情報に表示する commit hash を埋め込む
 FROM alpine AS commit-hash
-COPY .git .
-COPY slackbot_settings.py .
+COPY .git slackbot_settings.py ./
 RUN apk add --no-cache -U git
 RUN sed -i "s/^\(GIT_COMMIT_HASH = \).*\$/\1'$(git rev-parse HEAD)'/" slackbot_settings.py
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # バージョン情報に表示する commit hash を埋め込む
 FROM alpine:3.12 AS commit-hash
-COPY .git slackbot_settings.py ./
+COPY . .
 RUN apk add --no-cache -U git=2.26.2-r0
 RUN sed -i "s/^\(GIT_COMMIT_HASH = \).*\$/\1'$(git rev-parse HEAD)'/" slackbot_settings.py
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,9 @@ RUN apk add --no-cache -t .used-packages postgresql-libs=12.4-r0 && \
     apk --purge del .build-deps && \
     rm -rf ~/.cache
 
-COPY *.py library plugins ./
+COPY *.py ./
+COPY library library
+COPY plugins plugins
 COPY --from=commit-hash slackbot_settings.py slackbot_settings.py
 
 CMD ["python", "entrypoint.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN apk add --no-cache -t .used-packages postgresql-libs=12.4-r0 && \
 COPY *.py ./
 COPY library library
 COPY plugins plugins
+COPY setup setup
 COPY --from=commit-hash slackbot_settings.py slackbot_settings.py
 
 ENV GIT_PYTHON_REFRESH=quiet

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # バージョン情報に表示する commit hash を埋め込む
-FROM alpine AS commit-hash
+FROM alpine:3.12 AS commit-hash
 COPY .git slackbot_settings.py ./
-RUN apk add --no-cache -U git
+RUN apk add --no-cache -U git=2.26.2-r0
 RUN sed -i "s/^\(GIT_COMMIT_HASH = \).*\$/\1'$(git rev-parse HEAD)'/" slackbot_settings.py
 
-FROM python:3.8.5-alpine
+FROM python:3.8.5-alpine3.12
 
 WORKDIR /usr/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,10 @@
 FROM alpine AS commit-hash
 COPY .git .
 COPY slackbot_settings.py .
-RUN apk add -U git
+RUN apk add --no-cache -U git
 RUN sed -i "s/^\(GIT_COMMIT_HASH = \).*\$/\1'$(git rev-parse HEAD)'/" slackbot_settings.py
 
 FROM python:3.8.5-alpine
-
-ENV WORKON_HOME=/usr/src/venv
 
 WORKDIR /usr/src/app
 
@@ -24,7 +22,9 @@ RUN apk add --no-cache -t .used-packages postgresql-libs=12.4-r0 && \
     apk add --no-cache -t .build-deps jpeg-dev=9d-r0 zlib-dev=1.2.11-r3 gcc=9.3.0-r2 musl-dev=1.1.24-r9 postgresql-dev=12.4-r0 git=2.26.2-r0 && \
     pip install pipenv==2020.6.2 --no-cache-dir && \
     pipenv install --system && \
-    apk --purge del .build-deps
+    pip uninstall -y pipenv virtualenv && \
+    apk --purge del .build-deps && \
+    rm -rf ~/.cache
 
 COPY *.py library plugins ./
 COPY --from=commit-hash slackbot_settings.py slackbot_settings.py

--- a/plugins/hato.py
+++ b/plugins/hato.py
@@ -247,11 +247,14 @@ def version(client: BaseClient):
     str_ver = "バージョン情報\n```" \
               f"Version {VERSION}"
 
-    try:
-        repo = Repo()
-        str_ver += f" (Commit {repo.head.commit.hexsha[:7]})"
-    except InvalidGitRepositoryError:
-        pass
+    if conf.GIT_COMMIT_HASH:
+        str_ver += f" (Commit {conf.GIT_COMMIT_HASH[:7]})"
+    else:
+        try:
+            repo = Repo()
+            str_ver += f" (Commit {repo.head.commit.hexsha[:7]})"
+        except InvalidGitRepositoryError:
+            pass
 
     str_ver += "\n" \
                "Copyright (C) 2020 hato-bot Development team\n" \

--- a/slackbot_settings.py
+++ b/slackbot_settings.py
@@ -33,3 +33,5 @@ YAHOO_API_TOKEN = str(os.environ['YAHOO_API_TOKEN'])
 # Slack bot用の設定
 DEFAULT_REPLY = "使い方がわからない時は `help` とメンションするっぽ!"
 PLUGINS = ['plugins']
+
+GIT_COMMIT_HASH = str(os.environ.get('GIT_COMMIT_HASH'))


### PR DESCRIPTION
## Why

fix #187 
docker image のサイズを小さくしたい

## What

> git 系のファイルはバージョン情報で commit hash を出すために使っているらしい #287
> commit hash だけ埋め込めばファイルサイズはかなり減らせる

> pipenv はパッケージのインストール時以外は必要ないはず
> docker なので環境を分離する必要もないので pipenv install --system でインストールすれば消せる

> /usr/src/app 以下のファイルは .dockerignore に書けばよさそう

`.git` は context に入れたかったので COPY するファイルを個別で指定した

<details>

```console
$ docker save hato-bot | dlayer -n 100

====================================================================================================
 5.6 MB 	 $ #(nop) ADD file:c92c248239f8c7b9b3c067650954815f391b7bcb09023f984972c082ace2a8d0 in /
====================================================================================================
 2.6 MB 	 lib/libcrypto.so.1.1
 841 kB 	 bin/busybox
 596 kB 	 lib/ld-musl-x86_64.so.1
 524 kB 	 lib/libssl.so.1.1
 216 kB 	 etc/ssl/certs/ca-certificates.crt
 211 kB 	 sbin/apk
 100 kB 	 lib/libz.so.1.2.11
  96 kB 	 usr/lib/libtls-standalone.so.1.0.0
  80 kB 	 usr/bin/scanelf
  53 kB 	 usr/bin/getent
  38 kB 	 usr/bin/getconf
  26 kB 	 usr/lib/engines-1.1/padlock.so
  26 kB 	 usr/bin/iconv
  23 kB 	 usr/lib/engines-1.1/afalg.so
  14 kB 	 etc/services
  14 kB 	 sbin/mkmntdirs
  14 kB 	 usr/bin/ssl_client
  14 kB 	 usr/lib/engines-1.1/capi.so
  12 kB 	 lib/apk/db/installed
  11 kB 	 etc/ssl/openssl.cnf
  11 kB 	 etc/ssl/openssl.cnf.dist
  11 kB 	 lib/apk/db/scripts.tar
 7.6 kB 	 etc/ssl/misc/CA.pl
 6.6 kB 	 etc/ssl/misc/tsget.pl
 5.3 kB 	 etc/udhcpd.conf
 3.1 kB 	 usr/share/udhcpc/default.script
 2.0 kB 	 etc/modprobe.d/blacklist.conf
 1.9 kB 	 etc/protocols
 1.5 kB 	 etc/modprobe.d/aliases.conf
 1.3 kB 	 lib/sysctl.d/00-alpine.conf
 1.2 kB 	 etc/passwd
  682 B 	 etc/group
  570 B 	 etc/inittab
  451 B 	 etc/apk/keys/alpine-devel@lists.alpinelinux.org-4a6a0840.rsa.pub
  451 B 	 etc/apk/keys/alpine-devel@lists.alpinelinux.org-5243ef4b.rsa.pub
  451 B 	 etc/apk/keys/alpine-devel@lists.alpinelinux.org-5261cecb.rsa.pub
  451 B 	 usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-4a6a0840.rsa.pub
  451 B 	 usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-5243ef4b.rsa.pub
  451 B 	 usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-524d27bb.rsa.pub
  451 B 	 usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-5261cecb.rsa.pub
  451 B 	 usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-58199dcc.rsa.pub
  451 B 	 usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-58cbb476.rsa.pub
  451 B 	 usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-58e4f17d.rsa.pub
  451 B 	 usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-5e69ca50.rsa.pub
  422 B 	 etc/shadow
  412 B 	 etc/ssl/ct_log_list.cnf
  412 B 	 etc/ssl/ct_log_list.cnf.dist
  393 B 	 sbin/ldconfig
  295 B 	 etc/profile.d/color_prompt
  283 B 	 etc/crontabs/root
  283 B 	 etc/motd
  238 B 	 etc/profile
  218 B 	 etc/network/if-up.d/dad
  164 B 	 etc/os-release
  140 B 	 etc/logrotate.d/acpid
  122 B 	 etc/modprobe.d/i386.conf
  101 B 	 etc/apk/repositories
   91 B 	 etc/modprobe.d/kms.conf
   89 B 	 etc/fstab
   79 B 	 etc/hosts
   76 B 	 lib/apk/db/triggers
   65 B 	 etc/securetty
   59 B 	 etc/apk/world
   54 B 	 etc/issue
   53 B 	 etc/sysctl.conf
   52 B 	 usr/bin/ldd
   40 B 	 etc/profile.d/locale
   38 B 	 etc/shells
   15 B 	 etc/modules
   10 B 	 etc/hostname
    7 B 	 etc/alpine-release
    7 B 	 etc/apk/arch
    0 B 	 bin/arch
    0 B 	 bin/ash
    0 B 	 bin/base64
    0 B 	 bin/bbconfig
    0 B 	 bin/cat
    0 B 	 bin/chgrp
    0 B 	 bin/chmod
    0 B 	 bin/chown
    0 B 	 bin/conspy
    0 B 	 bin/cp
    0 B 	 bin/date
    0 B 	 bin/dd
    0 B 	 bin/df
    0 B 	 bin/dmesg
    0 B 	 bin/dnsdomainname
    0 B 	 bin/dumpkmap
    0 B 	 bin/echo
    0 B 	 bin/ed
    0 B 	 bin/egrep
    0 B 	 bin/false
    0 B 	 bin/fatattr
    0 B 	 bin/fdflush
    0 B 	 bin/fgrep
    0 B 	 bin/fsync
    0 B 	 bin/getopt
    0 B 	 bin/grep
    0 B 	 bin/gunzip
    0 B 	 bin/gzip

====================================================================================================
 497 kB 	 $ apk add --no-cache ca-certificates
====================================================================================================
 214 kB 	 etc/ssl/certs/ca-certificates.crt
  22 kB 	 lib/apk/db/installed
  14 kB 	 usr/bin/c_rehash
  14 kB 	 usr/sbin/update-ca-certificates
  13 kB 	 lib/apk/db/scripts.tar
 5.6 kB 	 etc/ca-certificates.conf
 2.8 kB 	 usr/share/ca-certificates/mozilla/ACCVRAIZ1.crt
 2.6 kB 	 usr/share/ca-certificates/mozilla/Chambers_of_Commerce_Root_-_2008.crt
 2.6 kB 	 usr/share/ca-certificates/mozilla/Global_Chambersign_Root_-_2008.crt
 2.4 kB 	 usr/share/ca-certificates/mozilla/QuoVadis_Root_CA_3.crt
 2.3 kB 	 usr/share/ca-certificates/mozilla/Certigna_Root_CA.crt
 2.2 kB 	 usr/share/ca-certificates/mozilla/E-Tugra_Certification_Authority.crt
 2.2 kB 	 usr/share/ca-certificates/mozilla/Entrust_Root_Certification_Authority_-_G4.crt
 2.2 kB 	 usr/share/ca-certificates/mozilla/TrustCor_RootCert_CA-2.crt
 2.2 kB 	 usr/share/ca-certificates/mozilla/Autoridad_de_Certificacion_Firmaprofesional_CIF_A62634068.crt
 2.2 kB 	 usr/share/ca-certificates/mozilla/Hellenic_Academic_and_Research_Institutions_RootCA_2015.crt
 2.1 kB 	 usr/share/ca-certificates/mozilla/Izenpe.com.crt
 2.1 kB 	 usr/share/ca-certificates/mozilla/SSL.com_EV_Root_Certification_Authority_RSA_R2.crt
 2.1 kB 	 usr/share/ca-certificates/mozilla/SSL.com_Root_Certification_Authority_RSA.crt
 2.1 kB 	 usr/share/ca-certificates/mozilla/USERTrust_RSA_Certification_Authority.crt
 2.1 kB 	 usr/share/ca-certificates/mozilla/COMODO_RSA_Certification_Authority.crt
 2.1 kB 	 usr/share/ca-certificates/mozilla/Certum_Trusted_Network_CA_2.crt
 2.1 kB 	 usr/share/ca-certificates/mozilla/QuoVadis_Root_CA.crt
 2.1 kB 	 usr/share/ca-certificates/mozilla/Hongkong_Post_Root_CA_3.crt
 2.1 kB 	 usr/share/ca-certificates/mozilla/Staat_der_Nederlanden_Root_CA_-_G2.crt
 2.1 kB 	 usr/share/ca-certificates/mozilla/LuxTrust_Global_Root_2.crt
 2.0 kB 	 usr/share/ca-certificates/mozilla/Actalis_Authentication_Root_CA.crt
 2.0 kB 	 usr/share/ca-certificates/mozilla/SwissSign_Silver_CA_-_G2.crt
 2.0 kB 	 usr/share/ca-certificates/mozilla/SwissSign_Gold_CA_-_G2.crt
 2.0 kB 	 usr/share/ca-certificates/mozilla/QuoVadis_Root_CA_2.crt
 2.0 kB 	 usr/share/ca-certificates/mozilla/ePKI_Root_Certification_Authority.crt
 2.0 kB 	 usr/share/ca-certificates/mozilla/DigiCert_Trusted_Root_G4.crt
 2.0 kB 	 usr/share/ca-certificates/mozilla/CFCA_EV_ROOT.crt
 2.0 kB 	 usr/share/ca-certificates/mozilla/GDCA_TrustAUTH_R5_ROOT.crt
 2.0 kB 	 usr/share/ca-certificates/mozilla/AC_RAIZ_FNMT-RCM.crt
 2.0 kB 	 usr/share/ca-certificates/mozilla/GlobalSign_Root_CA_-_R6.crt
 2.0 kB 	 usr/share/ca-certificates/mozilla/Staat_der_Nederlanden_Root_CA_-_G3.crt
 1.9 kB 	 usr/share/ca-certificates/mozilla/Staat_der_Nederlanden_EV_Root_CA.crt
 1.9 kB 	 usr/share/ca-certificates/mozilla/Taiwan_GRCA.crt
 1.9 kB 	 usr/share/ca-certificates/mozilla/GeoTrust_Universal_CA_2.crt
 1.9 kB 	 usr/share/ca-certificates/mozilla/ISRG_Root_X1.crt
 1.9 kB 	 usr/share/ca-certificates/mozilla/CA_Disig_Root_R2.crt
 1.9 kB 	 usr/share/ca-certificates/mozilla/GeoTrust_Universal_CA.crt
 1.9 kB 	 usr/share/ca-certificates/mozilla/IdenTrust_Public_Sector_Root_CA_1.crt
 1.9 kB 	 usr/share/ca-certificates/mozilla/IdenTrust_Commercial_Root_CA_1.crt
 1.9 kB 	 usr/share/ca-certificates/mozilla/QuoVadis_Root_CA_1_G3.crt
 1.9 kB 	 usr/share/ca-certificates/mozilla/QuoVadis_Root_CA_2_G3.crt
 1.9 kB 	 usr/share/ca-certificates/mozilla/QuoVadis_Root_CA_3_G3.crt
 1.9 kB 	 usr/share/ca-certificates/mozilla/Buypass_Class_2_Root_CA.crt
 1.9 kB 	 usr/share/ca-certificates/mozilla/Buypass_Class_3_Root_CA.crt
 1.9 kB 	 usr/share/ca-certificates/mozilla/GTS_Root_R1.crt
 1.9 kB 	 usr/share/ca-certificates/mozilla/GTS_Root_R2.crt
 1.9 kB 	 usr/share/ca-certificates/mozilla/UCA_Extended_Validation_Root.crt
 1.9 kB 	 usr/share/ca-certificates/mozilla/EC-ACC.crt
 1.9 kB 	 usr/share/ca-certificates/mozilla/AffirmTrust_Premium.crt
 1.9 kB 	 usr/share/ca-certificates/mozilla/UCA_Global_G2_Root.crt
 1.9 kB 	 usr/share/ca-certificates/mozilla/Amazon_Root_CA_2.crt
 1.9 kB 	 usr/share/ca-certificates/mozilla/TWCA_Global_Root_CA.crt
 1.9 kB 	 usr/share/ca-certificates/mozilla/TeliaSonera_Root_CA_v1.crt
 1.7 kB 	 usr/share/ca-certificates/mozilla/VeriSign_Class_3_Public_Primary_Certification_Authority_-_G5.crt
 1.7 kB 	 usr/share/ca-certificates/mozilla/VeriSign_Universal_Root_Certification_Authority.crt
 1.6 kB 	 usr/share/ca-certificates/mozilla/Entrust_Root_Certification_Authority.crt
 1.6 kB 	 usr/share/ca-certificates/mozilla/TUBITAK_Kamu_SM_SSL_Kok_Sertifikasi_-_Surum_1.crt
 1.5 kB 	 usr/share/ca-certificates/mozilla/D-TRUST_Root_Class_3_CA_2_EV_2009.crt
 1.5 kB 	 usr/share/ca-certificates/mozilla/Entrust_Root_Certification_Authority_-_G2.crt
 1.5 kB 	 usr/share/ca-certificates/mozilla/Comodo_AAA_Services_root.crt
 1.5 kB 	 usr/share/ca-certificates/mozilla/D-TRUST_Root_Class_3_CA_2_2009.crt
 1.5 kB 	 usr/share/ca-certificates/mozilla/Hellenic_Academic_and_Research_Institutions_RootCA_2011.crt
 1.5 kB 	 usr/share/ca-certificates/mozilla/TrustCor_RootCert_CA-1.crt
 1.5 kB 	 usr/share/ca-certificates/mozilla/XRamp_Global_CA_Root.crt
 1.5 kB 	 usr/share/ca-certificates/mozilla/Entrust.net_Premium_2048_Secure_Server_CA.crt
 1.5 kB 	 usr/share/ca-certificates/mozilla/thawte_Primary_Root_CA_-_G3.crt
 1.5 kB 	 usr/share/ca-certificates/mozilla/TrustCor_ECA-1.crt
 1.5 kB 	 usr/share/ca-certificates/mozilla/thawte_Primary_Root_CA.crt
 1.5 kB 	 usr/share/ca-certificates/mozilla/COMODO_Certification_Authority.crt
 1.5 kB 	 usr/share/ca-certificates/mozilla/Verisign_Class_3_Public_Primary_Certification_Authority_-_G3.crt
 1.5 kB 	 usr/share/ca-certificates/mozilla/NetLock_Arany_=Class_Gold=_Főtanúsítvány.crt
 1.5 kB 	 usr/share/ca-certificates/mozilla/Starfield_Class_2_CA.crt
 1.5 kB 	 usr/share/ca-certificates/mozilla/Microsec_e-Szigno_Root_CA_2009.crt
 1.5 kB 	 usr/share/ca-certificates/mozilla/EE_Certification_Centre_Root_CA.crt
 1.4 kB 	 usr/share/ca-certificates/mozilla/Go_Daddy_Class_2_CA.crt
 1.4 kB 	 usr/share/ca-certificates/mozilla/GeoTrust_Primary_Certification_Authority_-_G3.crt
 1.4 kB 	 usr/share/ca-certificates/mozilla/OISTE_WISeKey_Global_Root_GA_CA.crt
 1.4 kB 	 usr/share/ca-certificates/mozilla/Starfield_Services_Root_Certificate_Authority_-_G2.crt
 1.4 kB 	 usr/share/ca-certificates/mozilla/Network_Solutions_Certificate_Authority.crt
 1.4 kB 	 usr/share/ca-certificates/mozilla/Starfield_Root_Certificate_Authority_-_G2.crt
 1.4 kB 	 usr/share/ca-certificates/mozilla/DigiCert_High_Assurance_EV_Root_CA.crt
 1.4 kB 	 usr/share/ca-certificates/mozilla/Go_Daddy_Root_Certificate_Authority_-_G2.crt
 1.4 kB 	 usr/share/ca-certificates/mozilla/T-TeleSec_GlobalRoot_Class_2.crt
 1.4 kB 	 usr/share/ca-certificates/mozilla/T-TeleSec_GlobalRoot_Class_3.crt
 1.4 kB 	 usr/share/ca-certificates/mozilla/Certum_Trusted_Network_CA.crt
 1.4 kB 	 usr/share/ca-certificates/mozilla/GlobalSign_Root_CA_-_R2.crt
 1.4 kB 	 usr/share/ca-certificates/mozilla/Secure_Global_CA.crt
 1.4 kB 	 usr/share/ca-certificates/mozilla/DigiCert_Assured_ID_Root_CA.crt
 1.4 kB 	 usr/share/ca-certificates/mozilla/SecureTrust_CA.crt
 1.3 kB 	 usr/share/ca-certificates/mozilla/OISTE_WISeKey_Global_Root_GB_CA.crt
 1.3 kB 	 usr/share/ca-certificates/mozilla/DigiCert_Global_Root_CA.crt
 1.3 kB 	 usr/share/ca-certificates/mozilla/Certigna.crt
 1.3 kB 	 usr/share/ca-certificates/mozilla/Cybertrust_Global_Root.crt
 1.3 kB 	 usr/share/ca-certificates/mozilla/DigiCert_Assured_ID_Root_G2.crt

====================================================================================================
  29 MB 	 $ set -ex && apk add --no-cache --virtual .fetch-deps gnupg tar xz && wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" && wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" && export GNUPGHOME="$(mktemp -d)" && gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEY" && gpg --batch --verify python.tar.xz.asc python.tar.xz && { command -v gpgconf >/dev/null && gpgconf --kill all || :; } && rm -rf "$GNUPGHOME" python.tar.xz.asc && mkdir -p /usr/src/python && tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz && rm python.tar.xz && apk add --no-cache --virtual .build-deps bluez-dev bzip2-dev coreutils dpkg-dev dpkg expat-dev findutils gcc gdbm-dev libc-dev libffi-dev libnsl-dev libtirpc-dev linux-headers make ncurses-dev openssl-dev pax-utils readline-dev sqlite-dev tcl-dev tk tk-dev util-linux-dev xz-dev zlib-dev && apk del --no-network .fetch-deps && cd /usr/src/python && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" && ./configure --build="$gnuArch" --enable-loadable-sqlite-extensions --enable-optimizations --enable-option-checking=fatal --enable-shared --with-system-expat --with-system-ffi --without-ensurepip && make -j "$(nproc)" EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000" LDFLAGS="-Wl,--strip-all" && make install && rm -rf /usr/src/python && find /usr/local -depth \( \( -type d -a \( -name test -o -name tests -o -name idle_test \) \) -o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) -o \( -type f -a -name 'wininst-*.exe' \) \) -exec rm -rf '{}' + && find /usr/local -type f -executable -not \( -name '*tkinter*' \) -exec scanelf --needed --nobanner --format '%n#p' '{}' ';' | tr ',' '\n' | sort -u | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' | xargs -rt apk add --no-cache --virtual .python-rundeps && apk del --no-network .build-deps && python3 --version
====================================================================================================
 3.6 MB 	 usr/local/lib/libpython3.8.so.1.0
 1.5 MB 	 usr/local/lib/python3.8/ensurepip/_bundled/pip-20.1.1-py2.py3-none-any.whl
 1.1 MB 	 usr/local/lib/python3.8/lib-dynload/unicodedata.cpython-38-x86_64-linux-gnu.so
 942 kB 	 usr/lib/libsqlite3.so.0.8.6
 805 kB 	 usr/lib/libkrb5.so.3.3
 676 kB 	 usr/local/lib/python3.8/pydoc_data/topics.py
 596 kB 	 lib/ld-musl-x86_64.so.1
 583 kB 	 usr/local/lib/python3.8/ensurepip/_bundled/setuptools-47.1.0-py3-none-any.whl
 368 kB 	 usr/lib/libncursesw.so.6.2
 343 kB 	 usr/local/lib/python3.8/lib-dynload/_decimal.cpython-38-x86_64-linux-gnu.so
 287 kB 	 usr/lib/libgssapi_krb5.so.2.2
 277 kB 	 usr/lib/libreadline.so.8.0
 272 kB 	 usr/local/lib/python3.8/lib-dynload/_codecs_jp.cpython-38-x86_64-linux-gnu.so
 229 kB 	 usr/local/lib/python3.8/_pydecimal.py
 183 kB 	 usr/local/lib/python3.8/lib-dynload/_ssl.cpython-38-x86_64-linux-gnu.so
 174 kB 	 usr/lib/libtirpc.so.3.0.0
 174 kB 	 usr/lib/libk5crypto.so.3.1
 169 kB 	 usr/local/lib/python3.8/tkinter/__init__.py
 162 kB 	 usr/local/lib/python3.8/lib-dynload/_codecs_hk.cpython-38-x86_64-linux-gnu.so
 158 kB 	 usr/local/lib/python3.8/lib-dynload/_codecs_cn.cpython-38-x86_64-linux-gnu.so
 150 kB 	 usr/local/lib/python3.8/lib-dynload/_pickle.cpython-38-x86_64-linux-gnu.so
 144 kB 	 usr/local/lib/python3.8/turtle.py
 141 kB 	 usr/local/lib/python3.8/lib-dynload/_codecs_kr.cpython-38-x86_64-linux-gnu.so
 140 kB 	 usr/local/lib/python3.8/lib-dynload/_datetime.cpython-38-x86_64-linux-gnu.so
 137 kB 	 usr/lib/libexpat.so.1.6.11
 137 kB 	 usr/lib/liblzma.so.5.2.5
 135 kB 	 usr/local/lib/python3.8/lib-dynload/_ctypes.cpython-38-x86_64-linux-gnu.so
 127 kB 	 usr/local/lib/python3.8/lib-dynload/_testcapi.cpython-38-x86_64-linux-gnu.so
 126 kB 	 usr/local/lib/python3.8/lib-dynload/_curses.cpython-38-x86_64-linux-gnu.so
 118 kB 	 usr/local/lib/python3.8/inspect.py
 112 kB 	 usr/local/lib/python3.8/lib-dynload/_codecs_tw.cpython-38-x86_64-linux-gnu.so
 107 kB 	 usr/local/lib/python3.8/pydoc.py
 107 kB 	 usr/local/lib/python3.8/email/_header_value_parser.py
 106 kB 	 usr/lib/libgssrpc.so.4.2
 104 kB 	 usr/local/lib/python3.8/doctest.py
 104 kB 	 usr/local/lib/python3.8/idlelib/configdialog.py
 104 kB 	 usr/lib/libkadm5srv_mit.so.12.0
 103 kB 	 usr/local/lib/python3.8/lib-dynload/_sha3.cpython-38-x86_64-linux-gnu.so
 101 kB 	 usr/local/lib/python3.8/urllib/request.py
  98 kB 	 usr/local/lib/python3.8/unittest/mock.py
  98 kB 	 usr/local/lib/python3.8/lib-dynload/_sqlite3.cpython-38-x86_64-linux-gnu.so
  96 kB 	 usr/local/lib/python3.8/argparse.py
  95 kB 	 usr/local/lib/python3.8/lib-dynload/_socket.cpython-38-x86_64-linux-gnu.so
  94 kB 	 usr/local/lib/python3.8/tarfile.py
  94 kB 	 usr/local/lib/python3.8/pickletools.py
  93 kB 	 usr/local/lib/python3.8/_pyio.py
  92 kB 	 usr/bin/gdbmtool
  89 kB 	 usr/local/lib/python3.8/lib-dynload/_blake2.cpython-38-x86_64-linux-gnu.so
  88 kB 	 usr/local/lib/python3.8/datetime.py
  88 kB 	 usr/local/lib/python3.8/zipfile.py
  84 kB 	 usr/lib/krb5/plugins/kdb/db2.so
  84 kB 	 usr/local/lib/python3.8/lib-dynload/_elementtree.cpython-38-x86_64-linux-gnu.so
  84 kB 	 usr/local/lib/python3.8/difflib.py
  84 kB 	 usr/lib/libkadm5clnt_mit.so.12.0
  84 kB 	 usr/lib/libnsl.so.2.0.0
  79 kB 	 usr/local/lib/python3.8/mailbox.py
  78 kB 	 usr/local/lib/python3.8/locale.py
  78 kB 	 usr/local/lib/python3.8/lib-dynload/array.cpython-38-x86_64-linux-gnu.so
  78 kB 	 usr/local/lib/python3.8/logging/__init__.py
  77 kB 	 usr/local/lib/python3.8/lib-dynload/_json.cpython-38-x86_64-linux-gnu.so
  77 kB 	 usr/local/lib/python3.8/subprocess.py
  77 kB 	 usr/local/lib/python3.8/tkinter/tix.py
  77 kB 	 usr/local/lib/python3.8/http/cookiejar.py
  77 kB 	 usr/local/lib/python3.8/config-3.8-x86_64-linux-gnu/Makefile
  76 kB 	 usr/lib/krb5/plugins/preauth/spake.so
  75 kB 	 usr/local/lib/python3.8/html/entities.py
  73 kB 	 usr/local/lib/python3.8/lib-dynload/pyexpat.cpython-38-x86_64-linux-gnu.so
  73 kB 	 usr/local/lib/python3.8/xml/etree/ElementTree.py
  73 kB 	 usr/local/lib/python3.8/asyncio/base_events.py
  72 kB 	 usr/local/lib/python3.8/lib-dynload/cmath.cpython-38-x86_64-linux-gnu.so
  72 kB 	 usr/lib/libkdb5.so.10.0
  71 kB 	 usr/local/lib/python3.8/ipaddress.py
  69 kB 	 usr/local/lib/python3.8/lib-dynload/math.cpython-38-x86_64-linux-gnu.so
  69 kB 	 usr/local/lib/python3.8/typing.py
  68 kB 	 usr/lib/libformw.so.6.2
  67 kB 	 usr/local/lib/python3.8/xml/dom/minidom.py
  66 kB 	 usr/local/lib/python3.8/idlelib/editor.py
  64 kB 	 usr/local/lib/python3.8/pickle.py
  63 kB 	 usr/local/lib/python3.8/idlelib/help.html
  63 kB 	 usr/local/lib/python3.8/pdb.py
  62 kB 	 usr/local/lib/python3.8/importlib/_bootstrap_external.py
  62 kB 	 usr/local/lib/python3.8/lib-dynload/_asyncio.cpython-38-x86_64-linux-gnu.so
  61 kB 	 usr/local/lib/python3.8/lib-dynload/_tkinter.cpython-38-x86_64-linux-gnu.so
  60 kB 	 usr/local/lib/python3.8/optparse.py
  60 kB 	 usr/local/lib/python3.8/unittest/case.py
  58 kB 	 usr/local/lib/python3.8/lib-dynload/_struct.cpython-38-x86_64-linux-gnu.so
  58 kB 	 usr/lib/libbz2.so.1.0.8
  58 kB 	 usr/local/lib/python3.8/logging/handlers.py
  57 kB 	 usr/local/lib/python3.8/lib-dynload/_testbuffer.cpython-38-x86_64-linux-gnu.so
  57 kB 	 usr/local/lib/python3.8/idlelib/pyshell.py
  57 kB 	 usr/local/lib/python3.8/tkinter/ttk.py
  56 kB 	 usr/local/lib/python3.8/idlelib/ChangeLog
  56 kB 	 usr/local/lib/python3.8/http/client.py
  54 kB 	 usr/local/lib/python3.8/lib-dynload/_multibytecodec.cpython-38-x86_64-linux-gnu.so
  54 kB 	 usr/local/lib/python3.8/configparser.py
  54 kB 	 usr/local/lib/python3.8/imaplib.py
  52 kB 	 usr/local/lib/python3.8/pathlib.py
  51 kB 	 usr/lib/libgdbm.so.4.0.0
  51 kB 	 usr/local/lib/python3.8/threading.py
  51 kB 	 usr/local/lib/python3.8/ssl.py

====================================================================================================
    0 B 	 $ cd /usr/local/bin && ln -s idle3 idle && ln -s pydoc3 pydoc && ln -s python3 python && ln -s python3-config python-config
====================================================================================================
    0 B 	 usr/local/bin/idle
    0 B 	 usr/local/bin/pydoc
    0 B 	 usr/local/bin/python
    0 B 	 usr/local/bin/python-config

====================================================================================================
 7.2 MB 	 $ # multiple line script
set -ex
wget -O get-pip.py "$PYTHON_GET_PIP_URL"
echo "$PYTHON_GET_PIP_SHA256 *get-pip.py" | sha256sum -c -
python get-pip.py --disable-pip-version-check --no-cache-dir "pip==$PYTHON_PIP_VERSION"
pip --version
find /usr/local -depth \( \( -type d -a \( -name test -o -name tests -o -name idle_test \) \) -o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \) -exec rm -rf '{}' +
rm -f get-pip.py
====================================================================================================
 918 kB 	 usr/local/lib/python3.8/site-packages/pip/_vendor/distlib
 485 kB 	 usr/local/lib/python3.8/site-packages/pip/_vendor/html5lib
 367 kB 	 usr/local/lib/python3.8/site-packages/pip/_vendor/chardet
 347 kB 	 usr/local/lib/python3.8/site-packages/pip/_vendor/urllib3
 285 kB 	 usr/local/lib/python3.8/site-packages/pip/_vendor/certifi
 273 kB 	 usr/local/lib/python3.8/site-packages/pip/_vendor/pyparsing.py
 262 kB 	 usr/local/lib/python3.8/site-packages/pip/_vendor/idna
 258 kB 	 usr/local/lib/python3.8/site-packages/setuptools/_distutils/command
 232 kB 	 usr/local/lib/python3.8/site-packages/pkg_resources/_vendor/pyparsing.py
 232 kB 	 usr/local/lib/python3.8/site-packages/setuptools/_vendor/pyparsing.py
 174 kB 	 usr/local/lib/python3.8/site-packages/pip/_vendor/requests
 140 kB 	 usr/local/lib/python3.8/site-packages/pip/_internal/utils
 109 kB 	 usr/local/lib/python3.8/site-packages/pip/_internal/req
 109 kB 	 usr/local/lib/python3.8/site-packages/pip/_vendor/pkg_resources
 108 kB 	 usr/local/lib/python3.8/site-packages/pkg_resources/__init__.py
 104 kB 	 usr/local/lib/python3.8/site-packages/pip/_internal/commands
  94 kB 	 usr/local/lib/python3.8/site-packages/pkg_resources/_vendor/packaging
  94 kB 	 usr/local/lib/python3.8/site-packages/setuptools/_vendor/packaging
  94 kB 	 usr/local/lib/python3.8/site-packages/pip/_vendor/packaging
  91 kB 	 usr/local/lib/python3.8/site-packages/pip/_internal/cli
  86 kB 	 usr/local/lib/python3.8/site-packages/setuptools/command/easy_install.py
  81 kB 	 usr/local/lib/python3.8/site-packages/pip/_internal/operations
  80 kB 	 usr/local/lib/python3.8/site-packages/pip/_internal/resolution
  80 kB 	 usr/local/lib/python3.8/site-packages/pip/_vendor/ipaddress.py
  75 kB 	 usr/local/lib/python3.8/site-packages/setuptools/gui-64.exe
  75 kB 	 usr/local/lib/python3.8/site-packages/setuptools/cli-64.exe
  66 kB 	 usr/local/lib/python3.8/site-packages/setuptools/cli-32.exe
  66 kB 	 usr/local/lib/python3.8/site-packages/setuptools/cli.exe
  66 kB 	 usr/local/lib/python3.8/site-packages/setuptools/gui-32.exe
  66 kB 	 usr/local/lib/python3.8/site-packages/setuptools/gui.exe
  62 kB 	 usr/local/lib/python3.8/site-packages/pip/_internal/vcs
  60 kB 	 usr/local/lib/python3.8/site-packages/pip/_internal/index
  58 kB 	 usr/local/lib/python3.8/site-packages/pip-20.2.3.dist-info/RECORD
  51 kB 	 usr/local/lib/python3.8/site-packages/setuptools/msvc.py
  51 kB 	 usr/local/lib/python3.8/site-packages/pip/_vendor/toml
  50 kB 	 usr/local/lib/python3.8/site-packages/setuptools/_distutils/dist.py
  49 kB 	 usr/local/lib/python3.8/site-packages/pip/_internal/network
  47 kB 	 usr/local/lib/python3.8/site-packages/setuptools/_distutils/ccompiler.py
  45 kB 	 usr/local/lib/python3.8/site-packages/pip/_vendor/msgpack
  44 kB 	 usr/local/lib/python3.8/site-packages/pip/_vendor/distro.py
  43 kB 	 usr/local/lib/python3.8/site-packages/pip/_vendor/pep517
  42 kB 	 usr/local/lib/python3.8/site-packages/pip/_vendor/cachecontrol
  41 kB 	 usr/local/lib/python3.8/site-packages/setuptools/package_index.py
  38 kB 	 usr/local/lib/python3.8/site-packages/setuptools/dist.py
  34 kB 	 usr/local/lib/python3.8/site-packages/pip/_vendor/six.py
  34 kB 	 usr/local/lib/python3.8/site-packages/pip/_internal/models
  32 kB 	 usr/local/lib/python3.8/site-packages/pip/_vendor/webencodings
  30 kB 	 usr/local/lib/python3.8/site-packages/setuptools/_distutils/msvc9compiler.py
  27 kB 	 usr/local/lib/python3.8/site-packages/pip/_vendor/colorama
  26 kB 	 usr/local/lib/python3.8/site-packages/wheel/vendored/packaging
  26 kB 	 usr/local/lib/python3.8/site-packages/pip/_vendor/appdirs.py
  25 kB 	 usr/local/lib/python3.8/site-packages/setuptools/command/egg_info.py
  25 kB 	 usr/local/lib/python3.8/site-packages/pkg_resources/_vendor/appdirs.py
  24 kB 	 usr/local/lib/python3.8/site-packages/pip/_vendor/resolvelib
  24 kB 	 usr/local/lib/python3.8/site-packages/setuptools/_distutils/msvccompiler.py
  23 kB 	 usr/local/lib/python3.8/site-packages/setuptools-50.3.0.dist-info/RECORD
  22 kB 	 usr/local/lib/python3.8/site-packages/setuptools/config.py
  21 kB 	 usr/local/lib/python3.8/site-packages/setuptools/_distutils/sysconfig.py
  21 kB 	 usr/local/lib/python3.8/site-packages/setuptools/_distutils/util.py
  21 kB 	 usr/local/lib/python3.8/site-packages/setuptools/_distutils/_msvccompiler.py
  18 kB 	 usr/local/lib/python3.8/site-packages/wheel/bdist_wheel.py
  18 kB 	 usr/local/lib/python3.8/site-packages/setuptools/command/bdist_egg.py
  18 kB 	 usr/local/lib/python3.8/site-packages/setuptools/_distutils/cmd.py
  18 kB 	 usr/local/lib/python3.8/site-packages/setuptools/_distutils/fancy_getopt.py
  17 kB 	 usr/local/lib/python3.8/site-packages/pip/_vendor/contextlib2.py
  16 kB 	 usr/local/lib/python3.8/site-packages/setuptools/_distutils/cygwinccompiler.py
  15 kB 	 usr/local/lib/python3.8/site-packages/setuptools/_vendor/ordered_set.py
  15 kB 	 usr/local/lib/python3.8/site-packages/setuptools/_distutils/bcppcompiler.py
  15 kB 	 usr/local/lib/python3.8/site-packages/wheel/macosx_libfile.py
  15 kB 	 usr/local/lib/python3.8/site-packages/setuptools/_distutils/unixccompiler.py
  14 kB 	 usr/local/lib/python3.8/site-packages/setuptools/sandbox.py
  14 kB 	 usr/local/lib/python3.8/site-packages/pip/_internal/configuration.py
  13 kB 	 usr/local/lib/python3.8/site-packages/setuptools/command/build_ext.py
  13 kB 	 usr/local/lib/python3.8/site-packages/setuptools/_distutils/filelist.py
  13 kB 	 usr/local/lib/python3.8/site-packages/pip/_internal/exceptions.py
  12 kB 	 usr/local/lib/python3.8/site-packages/setuptools/_distutils/version.py
  12 kB 	 usr/local/lib/python3.8/site-packages/setuptools/_distutils/text_file.py
  12 kB 	 usr/local/lib/python3.8/site-packages/pip/_internal/cache.py
  10 kB 	 usr/local/lib/python3.8/site-packages/setuptools/_distutils/extension.py
  10 kB 	 usr/local/lib/python3.8/site-packages/pip/_vendor/progress
  10 kB 	 usr/local/lib/python3.8/site-packages/setuptools/build_meta.py
  10 kB 	 usr/local/lib/python3.8/site-packages/pip/_vendor/retrying.py
 9.5 kB 	 usr/local/lib/python3.8/site-packages/pip/_internal/wheel_builder.py
 9.5 kB 	 usr/local/lib/python3.8/site-packages/wheel/cli/convert.py
 9.5 kB 	 usr/local/lib/python3.8/site-packages/setuptools/command/build_py.py
 9.5 kB 	 usr/local/lib/python3.8/site-packages/setuptools/command/test.py
 8.9 kB 	 usr/local/lib/python3.8/site-packages/setuptools/_distutils/core.py
 8.6 kB 	 usr/local/lib/python3.8/site-packages/setuptools/_distutils/archive_util.py
 8.5 kB 	 usr/local/lib/python3.8/site-packages/pip/_internal/distributions
 8.5 kB 	 usr/local/lib/python3.8/site-packages/setuptools/ssl_support.py
 8.3 kB 	 usr/local/lib/python3.8/site-packages/setuptools/wheel.py
 8.1 kB 	 usr/local/lib/python3.8/site-packages/setuptools/_distutils/file_util.py
 8.1 kB 	 usr/local/lib/python3.8/site-packages/pip/_internal/build_env.py
 8.0 kB 	 usr/local/lib/python3.8/site-packages/setuptools/command/develop.py
 7.8 kB 	 usr/local/lib/python3.8/site-packages/setuptools/_distutils/dir_util.py
 7.7 kB 	 usr/local/lib/python3.8/site-packages/setuptools/__init__.py
 7.4 kB 	 usr/local/lib/python3.8/site-packages/pip/_internal/pyproject.py
 7.3 kB 	 usr/local/lib/python3.8/site-packages/wheel/wheelfile.py
 7.2 kB 	 usr/local/lib/python3.8/site-packages/setuptools/command/upload_docs.py
 7.0 kB 	 usr/local/lib/python3.8/site-packages/setuptools/command/sdist.py

====================================================================================================
    0 B 	 $ WORKDIR /usr/src/app
====================================================================================================
    0 B 	 usr/src/app/.wh..wh..opq

====================================================================================================
  459 B 	 $ COPY Pipfile Pipfile # buildkit
====================================================================================================
  459 B 	 usr/src/app/Pipfile

====================================================================================================
  32 kB 	 $ COPY Pipfile.lock-3.8 Pipfile.lock # buildkit
====================================================================================================
  32 kB 	 usr/src/app/Pipfile.lock

====================================================================================================
  39 MB 	 $ apk add --no-cache -t .used-packages postgresql-libs=12.4-r0 && apk add --no-cache -t .build-deps jpeg-dev=9d-r0 zlib-dev=1.2.11-r3 gcc=9.3.0-r2 musl-dev=1.1.24-r9 postgresql-dev=12.4-r0 git=2.26.2-r0 && pip install pipenv==2020.6.2 --no-cache-dir && pipenv install --system && pip uninstall -y pipenv virtualenv && apk --purge del .build-deps && rm -rf ~/.cache # buildkit
====================================================================================================
 1.7 MB 	 usr/local/lib/python3.8/site-packages/mypy/typeshed/stdlib
 1.6 MB 	 usr/lib/libdb-5.3.so
 1.3 MB 	 usr/local/lib/python3.8/site-packages/mypyc/external/googletest
 998 kB 	 usr/local/lib/python3.8/site-packages/aiohttp/_http_parser.c
 996 kB 	 usr/local/lib/python3.8/site-packages/mypy/typeshed/third_party
 558 kB 	 usr/local/lib/python3.8/site-packages/PIL/_imaging.cpython-38-x86_64-linux-gnu.so
 476 kB 	 usr/local/lib/python3.8/site-packages/yarl/_quoting_c.c
 366 kB 	 usr/local/lib/python3.8/site-packages/pip/_vendor/chardet
 352 kB 	 usr/local/lib/python3.8/site-packages/pip/_vendor/__pycache__
 313 kB 	 usr/lib/libpq.so.5.12
 296 kB 	 usr/local/lib/python3.8/site-packages/typed_ast/_ast3.cpython-38-x86_64-linux-gnu.so
 295 kB 	 usr/local/lib/python3.8/site-packages/slack/web/classes
 289 kB 	 usr/local/lib/python3.8/site-packages/aiohttp/_frozenlist.c
 286 kB 	 usr/lib/libldap_r-2.4.so.2.10.13
 285 kB 	 usr/local/lib/python3.8/site-packages/psycopg2/_psycopg.cpython-38-x86_64-linux-gnu.so
 284 kB 	 usr/local/lib/python3.8/site-packages/pip/_vendor/html5lib
 282 kB 	 usr/local/lib/python3.8/site-packages/certifi/cacert.pem
 280 kB 	 usr/local/lib/python3.8/site-packages/mypy/checker.py
 261 kB 	 usr/lib/libldap-2.4.so.2.10.13
 258 kB 	 usr/local/lib/python3.8/site-packages/mypy/test/__pycache__
 241 kB 	 usr/local/lib/python3.8/site-packages/mypyc/irbuild/__pycache__
 239 kB 	 usr/local/lib/python3.8/site-packages/typed_ast/_ast27.cpython-38-x86_64-linux-gnu.so
 227 kB 	 usr/local/lib/python3.8/site-packages/mypy/semanal.py
 222 kB 	 usr/local/lib/python3.8/site-packages/pkg_resources/_vendor/__pycache__
 215 kB 	 usr/local/lib/python3.8/site-packages/mypy/checkexpr.py
 212 kB 	 usr/local/lib/python3.8/site-packages/aiohttp/_http_writer.c
 209 kB 	 usr/local/lib/python3.8/site-packages/aiohttp/_helpers.c
 208 kB 	 usr/local/lib/python3.8/site-packages/slack/web/__pycache__
 202 kB 	 usr/local/lib/python3.8/site-packages/idna/uts46data.py
 200 kB 	 usr/local/lib/python3.8/site-packages/aiohttp/_find_header.c
 199 kB 	 usr/local/lib/python3.8/site-packages/pip/_vendor/urllib3
 178 kB 	 usr/local/lib/python3.8/site-packages/werkzeug/debug/shared
 177 kB 	 usr/local/lib/python3.8/site-packages/idna/__pycache__/uts46data.cpython-38.pyc
 166 kB 	 usr/local/lib/python3.8/site-packages/mypy-0.782.dist-info/RECORD
 153 kB 	 usr/local/lib/python3.8/site-packages/mypy/__pycache__/checker.cpython-38.pyc
 144 kB 	 usr/local/lib/python3.8/site-packages/mypy/__pycache__/semanal.cpython-38.pyc
 139 kB 	 usr/local/lib/python3.8/site-packages/pip/_vendor/requests
 138 kB 	 usr/local/lib/python3.8/site-packages/mypy/build.py
 137 kB 	 usr/local/lib/python3.8/site-packages/aiohttp/_websocket.c
 127 kB 	 usr/local/lib/python3.8/site-packages/mypy/server/__pycache__
 120 kB 	 usr/local/lib/python3.8/site-packages/git/objects/submodule
 120 kB 	 usr/local/lib/python3.8/site-packages/mypy/__pycache__/checkexpr.cpython-38.pyc
 116 kB 	 usr/local/lib/python3.8/site-packages/PIL/Image.py
 114 kB 	 usr/local/lib/python3.8/site-packages/mypy/nodes.py
 109 kB 	 usr/local/lib/python3.8/site-packages/werkzeug/__pycache__/datastructures.cpython-38.pyc
 108 kB 	 usr/local/lib/python3.8/site-packages/mypyc/codegen/__pycache__
 108 kB 	 usr/local/lib/python3.8/site-packages/pip/_internal/utils
 108 kB 	 usr/local/lib/python3.8/site-packages/yarl/_quoting_c.cpython-38-x86_64-linux-gnu.so
 106 kB 	 usr/local/lib/python3.8/site-packages/distlib/t64.exe
 105 kB 	 usr/lib/libsasl2.so.3.0.0
 103 kB 	 usr/local/lib/python3.8/site-packages/pip/_vendor/distlib
 103 kB 	 usr/local/lib/python3.8/site-packages/mypyc/test-data/run.test
 102 kB 	 usr/local/lib/python3.8/site-packages/distlib/_backport/__pycache__
 101 kB 	 usr/local/lib/python3.8/site-packages/pip/_vendor/pkg_resources
 100 kB 	 usr/local/lib/python3.8/site-packages/werkzeug/datastructures.py
 100 kB 	 usr/local/lib/python3.8/site-packages/pkg_resources/__pycache__/__init__.cpython-38.pyc
 100 kB 	 usr/local/lib/python3.8/site-packages/distlib/w64.exe
  98 kB 	 usr/local/lib/python3.8/site-packages/mypy/__pycache__/nodes.cpython-38.pyc
  98 kB 	 usr/local/lib/python3.8/site-packages/flask/app.py
  98 kB 	 usr/local/lib/python3.8/site-packages/mypy/messages.py
  97 kB 	 usr/local/lib/python3.8/site-packages/distlib/t32.exe
  96 kB 	 usr/lib/libecpg.so.6.12
  93 kB 	 usr/local/lib/python3.8/site-packages/PIL/__pycache__/Image.cpython-38.pyc
  93 kB 	 usr/local/lib/python3.8/site-packages/distlib/_backport/tarfile.py
  92 kB 	 usr/local/lib/python3.8/site-packages/mypyc/ir/__pycache__
  90 kB 	 usr/local/lib/python3.8/site-packages/distlib/w32.exe
  89 kB 	 usr/local/lib/python3.8/site-packages/mypy/types.py
  88 kB 	 usr/local/lib/python3.8/site-packages/werkzeug/wrappers/__pycache__
  87 kB 	 usr/local/lib/python3.8/site-packages/slack/web/async_client.py
  86 kB 	 usr/local/lib/python3.8/site-packages/slack/web/client.py
  85 kB 	 usr/local/lib/python3.8/site-packages/attr/_make.py
  84 kB 	 usr/lib/libpgtypes.so.3.12
  84 kB 	 usr/local/lib/python3.8/site-packages/typing_extensions.py
  83 kB 	 usr/local/lib/python3.8/site-packages/mypy/__pycache__/build.cpython-38.pyc
  82 kB 	 usr/local/lib/python3.8/site-packages/mypy/__pycache__/types.cpython-38.pyc
  80 kB 	 usr/local/lib/python3.8/__pycache__/inspect.cpython-38.pyc
  79 kB 	 usr/local/lib/python3.8/site-packages/werkzeug/routing.py
  78 kB 	 usr/local/lib/python3.8/site-packages/mypy/__pycache__/messages.cpython-38.pyc
  78 kB 	 usr/local/lib/python3.8/site-packages/click/core.py
  76 kB 	 usr/local/lib/python3.8/site-packages/pip/_internal/req
  75 kB 	 usr/local/lib/python3.8/site-packages/flask/__pycache__/app.cpython-38.pyc
  73 kB 	 usr/local/lib/python3.8/site-packages/pip/_vendor/packaging
  72 kB 	 usr/local/lib/python3.8/urllib/__pycache__/request.cpython-38.pyc
  69 kB 	 usr/local/lib/python3.8/site-packages/pip/_internal/cli
  68 kB 	 usr/local/lib/python3.8/site-packages/werkzeug/__pycache__/routing.cpython-38.pyc
  68 kB 	 usr/local/lib/python3.8/site-packages/PIL/TiffImagePlugin.py
  67 kB 	 usr/local/lib/python3.8/site-packages/mypy/fastparse.py
  66 kB 	 usr/local/lib/python3.8/site-packages/jinja2/compiler.py
  66 kB 	 usr/local/lib/python3.8/site-packages/multidict/_multidict.cpython-38-x86_64-linux-gnu.so
  65 kB 	 usr/local/lib/python3.8/site-packages/__pycache__/typing_extensions.cpython-38.pyc
  65 kB 	 usr/local/lib/python3.8/logging/__pycache__/__init__.cpython-38.pyc
  65 kB 	 usr/local/lib/python3.8/site-packages/mypy/stubgen.py
  64 kB 	 usr/local/lib/python3.8/site-packages/mypyc/test-data/irbuild-basic.test
  64 kB 	 usr/local/lib/python3.8/site-packages/attr/__pycache__/_make.cpython-38.pyc
  63 kB 	 usr/local/lib/python3.8/site-packages/mypy/subtypes.py
  63 kB 	 usr/local/lib/python3.8/__pycache__/tarfile.cpython-38.pyc
  62 kB 	 usr/local/lib/python3.8/__pycache__/typing.cpython-38.pyc
  62 kB 	 usr/local/lib/python3.8/site-packages/pip/_internal/__pycache__
  62 kB 	 usr/local/lib/python3.8/__pycache__/argparse.cpython-38.pyc
  62 kB 	 usr/local/lib/python3.8/site-packages/click/__pycache__/core.cpython-38.pyc

====================================================================================================
 6.1 kB 	 $ COPY *.py ./ # buildkit
====================================================================================================
 3.0 kB 	 usr/src/app/run.py
 1.1 kB 	 usr/src/app/slackbot_settings.py
  689 B 	 usr/src/app/post_command.py
  627 B 	 usr/src/app/wait_db.py
  416 B 	 usr/src/app/create_env.py
  244 B 	 usr/src/app/entrypoint.py

====================================================================================================
  10 kB 	 $ COPY library library # buildkit
====================================================================================================
 3.7 kB 	 usr/src/app/library/vocabularydb.py
 2.0 kB 	 usr/src/app/library/clientclass.py
 1.6 kB 	 usr/src/app/library/earthquake.py
 1.3 kB 	 usr/src/app/library/geo.py
  906 B 	 usr/src/app/library/database.py
  464 B 	 usr/src/app/library/hukidasi.py
  223 B 	 usr/src/app/library/hatokaraage.py
    0 B 	 usr/src/app/library/.wh..wh..opq
    0 B 	 usr/src/app/library/__init__.py

====================================================================================================
  10 kB 	 $ COPY plugins plugins # buildkit
====================================================================================================
 9.3 kB 	 usr/src/app/plugins/hato.py
 1.3 kB 	 usr/src/app/plugins/analyze.py
    0 B 	 usr/src/app/plugins/.wh..wh..opq
    0 B 	 usr/src/app/plugins/__init__.py

====================================================================================================
 1.3 kB 	 $ COPY setup setup # buildkit
====================================================================================================
  493 B 	 usr/src/app/setup/docker-compose.yml
  481 B 	 usr/src/app/setup/pgsql-init/01_enable_ssl.sh
  216 B 	 usr/src/app/setup/pgsql/Dockerfile
   68 B 	 usr/src/app/setup/pgsql-init/02_init.sql
    0 B 	 usr/src/app/setup/.wh..wh..opq

====================================================================================================
 1.1 kB 	 $ COPY slackbot_settings.py slackbot_settings.py # buildkit
====================================================================================================
 1.1 kB 	 usr/src/app/slackbot_settings.py
```

</details>

```console
$ docker images
REPOSITORY                TAG                                        IMAGE ID            CREATED             SIZE
hato-bot                  develop                                    5d662ff3e2fd        22 seconds ago      206MB
hato-bot                  latest                                     ef29ce25fe95        4 minutes ago       81.4MB
```

206MB → 81.4MB の削減