### PR TITLE
Fix "ModuleNotFoundError: No module named 'psycopg2'"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ENV WORKON_HOME=/usr/src/venv
 
 WORKDIR /usr/src/app
 
+COPY Pipfile Pipfile
 COPY Pipfile.lock-3.8 Pipfile.lock
 
 # 実行時に必要なパッケージ (グループ名: .used-packages)


### PR DESCRIPTION
fix https://github.com/dev-hato/hato-bot/issues/366