### PR TITLE
Pipfile更新のPRのタイトルにバージョンを明記する

### DIFF
--- a/.github/workflows/pr-check-pipfile.yml
+++ b/.github/workflows/pr-check-pipfile.yml
@@ -74,7 +74,7 @@ jobs:
             github.pulls.list(pulls_list_params).then(list_res => {
               if (list_res.data.length === 0) {
                 const pulls_create_params = {
-                  title: "pipfileが更新されたので直してあげたよ！PRをマージしてね！ #${{github.event.pull_request.number}}",
+                  title: "pipfile (" + process.env.PYTHON_VERSION + ") が更新されたので直してあげたよ！PRをマージしてね！ #${{github.event.pull_request.number}}",
                   body: "鳩の唐揚げおいしい！😋😋😋 #${{github.event.pull_request.number}}",
                   ...pull_params
                 }

--- a/.github/workflows/pr-check-pipfile.yml
+++ b/.github/workflows/pr-check-pipfile.yml
@@ -20,6 +20,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          # ここでsubmodule持ってくるとdetached headにcommitして死ぬ
+          # submodule: 'recursive'
+          fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2.1.2
         with:


### PR DESCRIPTION
Pipfile更新のPRがどのバージョンに対するものなのか分かりづらいので、PRのタイトルにバージョンを明記します。
また、push時に `shallow update not allowed` にならないよう、全てのブランチをfetchするようにしています。
https://github.com/dev-hato/hato-bot/runs/1137894285?check_suite_focus=true#step:8:15