### PR TITLE
突然の死の枠部分でtextlintに怒られないようにする

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -24,7 +24,11 @@
     "no-mixed-zenkaku-and-hankaku-alphabet": true,
     "prefer-tari-tari": true,
     "preset-ja-spacing": true,
-    "preset-ja-technical-writing": true,
+    "preset-ja-technical-writing": {
+      "ja-no-successive-word": {
+        "allow": ["人人"]
+      }
+    },
     "preset-jtf-style": {
       "1.1.3.箇条書き": false,
       "4.3.1.丸かっこ（）": false

--- a/yarn.lock
+++ b/yarn.lock
@@ -2160,10 +2160,11 @@ textlint-rule-ja-no-space-between-full-width@^2.0.2:
     textlint-rule-helper "^2.1.1"
 
 textlint-rule-ja-no-successive-word@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/textlint-rule-ja-no-successive-word/-/textlint-rule-ja-no-successive-word-1.1.1.tgz#6cd8b102eaf6c133ee8dc461e3adb3fd519072c3"
-  integrity sha512-X3aQ9yCh+/oMQtROSyTue22mkQRnEod0oFCchVR7f/PabaMahfiSHozbBj7/tVg4umXhvar30xwEG3+OkhDfaw==
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/textlint-rule-ja-no-successive-word/-/textlint-rule-ja-no-successive-word-1.2.0.tgz#ba7597b54978388a5f8e53b9003bd9066f2111ad"
+  integrity sha512-5ki006mIOeElHtPk0WECR8xvW66I+o3lpzbRpvDSlEwjZwNeR4QHwByfBsl7KdScy945Vab1t5I0lCXXS7u3ow==
   dependencies:
+    "@textlint/regexp-string-matcher" "^1.1.0"
     kuromojin "^2.0.0"
 
 textlint-rule-ja-no-weak-phrase@^1.0.5:


### PR DESCRIPTION
突然の死の枠部分 ( `人人` ) に https://github.com/textlint-ja/textlint-rule-ja-no-successive-word  を適用しないようにします。

```
＿人人人人人人＿
＞　突然の死　＜
￣Y^Y^Y^Y^Y￣
```

https://github.com/dev-hato/sudden-death/pull/40 でエラーが出ないことを確認済み