### PR TITLE
よしよしは正しい日本語

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -28,7 +28,7 @@
       "ja-no-successive-word": {
         "allow": [
             "人人",
-            "よしよし"
+            "よし"
         ]
       }
     },

--- a/.textlintrc
+++ b/.textlintrc
@@ -26,7 +26,10 @@
     "preset-ja-spacing": true,
     "preset-ja-technical-writing": {
       "ja-no-successive-word": {
-        "allow": ["人人"]
+        "allow": [
+            "人人",
+            "よしよし"
+        ]
       }
     },
     "preset-jtf-style": {


### PR DESCRIPTION
`よしよし` をja-no-successive-wordの条件から除外します。