### PR TITLE
リリースのPR作成時のレビュアー指定修正

### DIFF
--- a/.github/workflows/pr-release-hato-bot.yml
+++ b/.github/workflows/pr-release-hato-bot.yml
@@ -58,14 +58,14 @@ jobs:
                 console.log(pulls_create_params)
                 github.pulls.create(pulls_create_params).then(create_res => {
                   const release_users = ["nakkaa"]
-                  const pulls_create_review_request_params = {
+                  const pulls_request_reviews_params = {
                     pull_number: create_res.data.number,
                     reviewers: release_users,
                     ...common_params
                   }
-                  console.log("call pulls.createReviewRequest:")
-                  console.log(pulls_create_review_request_params)
-                  github.pulls.createReviewRequest(pulls_create_review_request_params)
+                  console.log("call pulls.requestReviewers:")
+                  console.log(pulls_request_reviews_params)
+                  github.pulls.requestReviewers(pulls_request_reviews_params)
                   const issues_add_assignees_params = {
                     issue_number: create_res.data.number,
                     assignees: release_users,


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/runs/1356413069?check_suite_focus=true#step:4:82

```
Error: Unhandled error: TypeError: github.pulls.createReviewRequest is not a function
```

上記エラーはoctokitのバージョンアップに伴って、 `createReviewRequest` が `requestReviewers` に変更されたことによるものです: https://github.com/octokit/plugin-rest-endpoint-methods.js/releases/tag/v4.0.0
したがって、メソッドを置き換えます。