### PR TITLE
master->developのPRを作成するCI追加

### DIFF
--- a/.github/workflows/pr-merge-develop-hato-bot.yml
+++ b/.github/workflows/pr-merge-develop-hato-bot.yml
@@ -6,7 +6,7 @@ on:
       - master
 
 jobs:
-  # masterの差分をdevelopにマージするPRを作成するjob
+  # masterにコミットがpushされたら、それをdevelopに反映するPRを作成するjob
   # masterとdevelopの間でコミットログに差異が出ないようにする
   pr-master-to-develop:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-merge-develop-hato-bot.yml
+++ b/.github/workflows/pr-merge-develop-hato-bot.yml
@@ -42,7 +42,7 @@ jobs:
               if (list_res.data.length === 0) {
                 const pulls_create_params = {
                   title: "master -> develop",
-                  body: "鳩に加えられた変更は元のブランチに反映される",
+                  body: "鳩に加えられた変更は元のブランチに反映される\ndevelopに新たなコミットがpushされる前にマージしてね！",
                   ...pull_params
                 }
                 console.log("call pulls.create:")

--- a/.github/workflows/pr-merge-develop-hato-bot.yml
+++ b/.github/workflows/pr-merge-develop-hato-bot.yml
@@ -42,7 +42,7 @@ jobs:
               if (list_res.data.length === 0) {
                 const pulls_create_params = {
                   title: "master -> develop",
-                  body: "鳩に加えられた変更は元のブランチに反映される\ndevelopに新たなコミットがpushされる前にマージしてね！",
+                  body: "鳩の歴史は同期される\ndevelopに新たなコミットがpushされる前にマージしてね！",
                   ...pull_params
                 }
                 console.log("call pulls.create:")

--- a/.github/workflows/pr-merge-develop-hato-bot.yml
+++ b/.github/workflows/pr-merge-develop-hato-bot.yml
@@ -18,17 +18,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Get diff
-        id: get_diff
-        run: |
-          result=$(git diff origin/master origin/develop)
-          echo "${result}"
-          result="${result//$'\n'/'%0A'}"
-          result="${result//$'\r'/'%0D'}"
-          echo "::set-output name=result::${result}"
       - name: Create PullRequest
         uses: actions/github-script@v3
-        if: steps.get_diff.outputs.result != ''
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/pr-merge-develop-hato-bot.yml
+++ b/.github/workflows/pr-merge-develop-hato-bot.yml
@@ -1,0 +1,79 @@
+name: pr-master-to-develop-hato-bot
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  # masterの差分をdevelopにマージするPRを作成するjob
+  # masterとdevelopの間でコミットログに差異が出ないようにする
+  pr-master-to-develop:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Get diff
+        id: get_diff
+        run: |
+          result=$(git diff origin/master origin/develop)
+          echo "${result}"
+          result="${result//$'\n'/'%0A'}"
+          result="${result//$'\r'/'%0D'}"
+          echo "::set-output name=result::${result}"
+      - name: Create PullRequest
+        uses: actions/github-script@v3
+        if: steps.get_diff.outputs.result != ''
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const common_params = {
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            }
+            const pull_params = {
+              head: "dev-hato:master",
+              base: "develop",
+              ...common_params
+            }
+            const pulls_list_params = {
+              state: "open",
+              ...pull_params
+            }
+            console.log("call pulls.list:")
+            console.log(pulls_list_params)
+            github.pulls.list(pulls_list_params).then(list_res => {
+              if (list_res.data.length === 0) {
+                const pulls_create_params = {
+                  title: "master -> develop",
+                  body: "鳩に加えられた変更は元のブランチに反映される",
+                  ...pull_params
+                }
+                console.log("call pulls.create:")
+                console.log(pulls_create_params)
+                github.pulls.create(pulls_create_params).then(create_res => {
+                  const release_users = ["nakkaa"]
+                  const pulls_request_reviews_params = {
+                    pull_number: create_res.data.number,
+                    reviewers: release_users,
+                    ...common_params
+                  }
+                  console.log("call pulls.requestReviewers:")
+                  console.log(pulls_request_reviews_params)
+                  github.pulls.requestReviewers(pulls_request_reviews_params)
+                  const issues_add_assignees_params = {
+                    issue_number: create_res.data.number,
+                    assignees: release_users,
+                    ...common_params
+                  }
+                  console.log("call issues.addAssignees:")
+                  console.log(issues_add_assignees_params)
+                  github.issues.addAssignees(issues_add_assignees_params)
+                })
+              }
+            })


### PR DESCRIPTION
developとmasterのコミットログの間に差異があることが原因で、リリースができないことがあります: https://github.com/dev-hato/hato-bot/pull/490#issuecomment-723459004
このような事態が発生しないよう、masterにコミットがpushされたら、それをdevelopに反映するPRを作成するCIを追加します。