### PR TITLE
pr-check-pipfile: 既存のPipfile.lockに対してpipenv lockを行うようにする

### DIFF
--- a/.github/workflows/pr-check-pipfile.yml
+++ b/.github/workflows/pr-check-pipfile.yml
@@ -30,8 +30,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install pipenv
         run: curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python
-     - name: Pipfile.lock-${{ matrix.python-version }} -> Pipfile.lock
-       run: git mv Pipfile.lock-${{ matrix.python-version }} Pipfile.lock
+      - name: Pipfile.lock-${{ matrix.python-version }} -> Pipfile.lock
+        run: git mv Pipfile.lock-${{ matrix.python-version }} Pipfile.lock
       - name: pipenv lock
         run: pipenv lock
       - name: Pipfile.lock -> Pipfile.lock-${{ matrix.python-version }}

--- a/.github/workflows/pr-check-pipfile.yml
+++ b/.github/workflows/pr-check-pipfile.yml
@@ -30,10 +30,12 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install pipenv
         run: curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python
+     - name: Pipfile.lock-${{ matrix.python-version }} -> Pipfile.lock
+       run: git mv Pipfile.lock-${{ matrix.python-version }} Pipfile.lock
       - name: pipenv lock
         run: pipenv lock
-      - name: pipfile mv
-        run: mv Pipfile.lock Pipfile.lock-${{ matrix.python-version }}
+      - name: Pipfile.lock -> Pipfile.lock-${{ matrix.python-version }}
+        run: git mv Pipfile.lock Pipfile.lock-${{ matrix.python-version }}
       # 差分があったときは差分を出力する
       - name: Show diff
         id: diff

--- a/.github/workflows/pr-check-pipfile.yml
+++ b/.github/workflows/pr-check-pipfile.yml
@@ -3,8 +3,6 @@ name: pr-check-pipfile
 # PipfileかPipfile-lock-*に差分があるPRに反応して起動する
 on:
   pull_request:
-    paths:
-      - "Pipfile*"
 
 env:
   WORKON_HOME: /tmp/.venv

--- a/Pipfile.lock-3.7
+++ b/Pipfile.lock-3.7
@@ -532,7 +532,7 @@
                 "sha256:dcab1d98b469a12a1a624ead220584391648790275560e1a43e54c5dceae65e7",
                 "sha256:dcaeec1b5f0eca77faea2a35ab790b4f3680ff75590bfcb7145986905aab2f58"
             ],
-            "markers": "python_version >= '3.6' and python_version < '4'",
+            "markers": "python_version >= '3.6' and python_version < '4.0'",
             "version": "==5.6.4"
         },
         "lazy-object-proxy": {

--- a/Pipfile.lock-3.7
+++ b/Pipfile.lock-3.7
@@ -606,7 +606,7 @@
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.15.0"
         },
         "toml": {
@@ -614,7 +614,7 @@
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.10.2"
         },
         "typed-ast": {

--- a/Pipfile.lock-3.7
+++ b/Pipfile.lock-3.7
@@ -54,7 +54,7 @@
                 "sha256:f326b3c1bbfda5b9308252ee0dcb30b612ee92b0e105d4abec70335fab5b1245",
                 "sha256:f411cb22115cb15452d099fec0ee636b06cf81bfb40ed9c02d30c8dc2bc2e3d1"
             ],
-            "markers": "python_version >= '3.6'",
+            "markers": "python_full_version >= '3.6.0'",
             "version": "==3.7.3"
         },
         "async-timeout": {
@@ -222,7 +222,7 @@
                 "sha256:f21756997ad8ef815d8ef3d34edd98804ab5ea337feedcd62fb52d22bf531281",
                 "sha256:fc13a9524bc18b6fb6e0dbec3533ba0496bbed167c56d0aabefd965584557d80"
             ],
-            "markers": "python_version >= '3.6'",
+            "markers": "python_full_version >= '3.6.0'",
             "version": "==5.1.0"
         },
         "mypy": {
@@ -485,7 +485,7 @@
                 "sha256:f0b059678fd549c66b89bed03efcabb009075bd131c248ecdf087bdb6faba24a",
                 "sha256:fcbb48a93e8699eae920f8d92f7160c03567b421bc17362a9ffbbd706a816f71"
             ],
-            "markers": "python_version >= '3.6'",
+            "markers": "python_full_version >= '3.6.0'",
             "version": "==1.6.3"
         }
     },
@@ -532,7 +532,7 @@
                 "sha256:dcab1d98b469a12a1a624ead220584391648790275560e1a43e54c5dceae65e7",
                 "sha256:dcaeec1b5f0eca77faea2a35ab790b4f3680ff75590bfcb7145986905aab2f58"
             ],
-            "markers": "python_version >= '3.6' and python_version < '4.0'",
+            "markers": "python_version >= '3.6' and python_version < '4'",
             "version": "==5.6.4"
         },
         "lazy-object-proxy": {

--- a/Pipfile.lock-3.8
+++ b/Pipfile.lock-3.8
@@ -531,7 +531,7 @@
                 "sha256:dcab1d98b469a12a1a624ead220584391648790275560e1a43e54c5dceae65e7",
                 "sha256:dcaeec1b5f0eca77faea2a35ab790b4f3680ff75590bfcb7145986905aab2f58"
             ],
-            "markers": "python_version >= '3.6' and python_version < '4'",
+            "markers": "python_version >= '3.6' and python_version < '4.0'",
             "version": "==5.6.4"
         },
         "lazy-object-proxy": {

--- a/Pipfile.lock-3.8
+++ b/Pipfile.lock-3.8
@@ -54,7 +54,7 @@
                 "sha256:f326b3c1bbfda5b9308252ee0dcb30b612ee92b0e105d4abec70335fab5b1245",
                 "sha256:f411cb22115cb15452d099fec0ee636b06cf81bfb40ed9c02d30c8dc2bc2e3d1"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==3.7.3"
         },
         "async-timeout": {
@@ -222,7 +222,7 @@
                 "sha256:f21756997ad8ef815d8ef3d34edd98804ab5ea337feedcd62fb52d22bf531281",
                 "sha256:fc13a9524bc18b6fb6e0dbec3533ba0496bbed167c56d0aabefd965584557d80"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==5.1.0"
         },
         "mypy": {
@@ -484,7 +484,7 @@
                 "sha256:f0b059678fd549c66b89bed03efcabb009075bd131c248ecdf087bdb6faba24a",
                 "sha256:fcbb48a93e8699eae920f8d92f7160c03567b421bc17362a9ffbbd706a816f71"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==1.6.3"
         }
     },
@@ -531,7 +531,7 @@
                 "sha256:dcab1d98b469a12a1a624ead220584391648790275560e1a43e54c5dceae65e7",
                 "sha256:dcaeec1b5f0eca77faea2a35ab790b4f3680ff75590bfcb7145986905aab2f58"
             ],
-            "markers": "python_version >= '3.6' and python_version < '4.0'",
+            "markers": "python_version >= '3.6' and python_version < '4'",
             "version": "==5.6.4"
         },
         "lazy-object-proxy": {
@@ -605,7 +605,7 @@
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.15.0"
         },
         "toml": {
@@ -613,7 +613,7 @@
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.10.2"
         },
         "urllib3": {

--- a/Pipfile.lock-3.8
+++ b/Pipfile.lock-3.8
@@ -531,7 +531,7 @@
                 "sha256:dcab1d98b469a12a1a624ead220584391648790275560e1a43e54c5dceae65e7",
                 "sha256:dcaeec1b5f0eca77faea2a35ab790b4f3680ff75590bfcb7145986905aab2f58"
             ],
-            "markers": "python_version >= '3.6' and python_version < '4.0'",
+            "markers": "python_version >= '3.6' and python_version < '4'",
             "version": "==5.6.4"
         },
         "lazy-object-proxy": {


### PR DESCRIPTION
pr-check-pipfileでは新たにPipfile.lockを作成し、既存のPipfile.lockと比較しています。
この方法だとPipfile.lockに表記揺れがある際にPR地獄になるので、既存のPipfile.lockに対してpipenv lockを行い、差分を比較する方式に変更します。