### PR TITLE
CIでのcheckout時にマージコミットしないようにする

### DIFF
--- a/.github/workflows/pr-check-yarn.yml
+++ b/.github/workflows/pr-check-yarn.yml
@@ -22,6 +22,7 @@ jobs:
           # ここでsubmodule持ってくるとdetached headにcommitして死ぬ
           # submodule: 'recursive'
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2.1.4
         with:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -21,6 +21,7 @@ jobs:
           # ここでsubmodule持ってくるとdetached headにcommitして死ぬ
           # submodule: 'recursive'
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2.2.1
         with:

--- a/.github/workflows/pr-textlint.yml
+++ b/.github/workflows/pr-textlint.yml
@@ -109,6 +109,7 @@ jobs:
           # ここでsubmodule持ってくるとdetached headにcommitして死ぬ
           # submodule: 'recursive'
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2.1.4
         with:


### PR DESCRIPTION
CIでcheckoutする際にマージコミットしてしまうと、GitHub Actionsによって投げられるPRが意図しない差分になってしまうことがあるので、PRのHEADをcheckoutするようにします。
参考: https://github.com/actions/checkout#checkout-pull-request-head-commit-instead-of-merge-commit