### PR TITLE
dependabotが1度に投げるPRの数を制限する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,19 +4,24 @@ updates:
   directory: "/"
   schedule:
     interval: "monthly"
+  open-pull-requests-limit: 1
 - package-ecosystem: docker
   directory: "/"
   schedule:
     interval: "monthly"
+  open-pull-requests-limit: 1
 - package-ecosystem: docker
   directory: "/setup/pgsql"
   schedule:
     interval: "monthly"
+  open-pull-requests-limit: 1
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
     interval: "monthly"
+  open-pull-requests-limit: 1
 - package-ecosystem: npm
   directory: "/"
   schedule:
     interval: "monthly"
+  open-pull-requests-limit: 1


### PR DESCRIPTION
dependabotが1度に投げるPRの数をそれぞれ1つずつにします。