### PR TITLE
Update super-linter

### DIFF
--- a/.github/linters/.isort.cfg
+++ b/.github/linters/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+force_sort_within_sections = True

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -376,7 +376,7 @@ jobs:
         run: cp -r ${{ env.venv_path }} /home/runner/work/_temp/_github_workflow/.venv
 
       - name: Lint files
-        uses: docker://github/super-linter:v3.10.0
+        uses: docker://github/super-linter:v3.15.5
         env:
           VALIDATE_ALL_CODEBASE: true
           VALIDATE_PYTHON_BLACK: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # バージョン情報に表示する commit hash を埋め込む
 FROM alpine:3.13.2 AS commit-hash
-COPY . .
+COPY . /
 RUN apk add --no-cache -U git
 RUN sed -i "s/^\(GIT_COMMIT_HASH = \).*\$/\1'$(git rev-parse HEAD)'/" slackbot_settings.py
 

--- a/library/clientclass.py
+++ b/library/clientclass.py
@@ -3,8 +3,8 @@
 """
 clientに使うclass
 """
-import os
 from abc import ABCMeta, abstractmethod
+import os
 
 from slack import WebClient
 import slackbot_settings as conf

--- a/library/clientclass.py
+++ b/library/clientclass.py
@@ -6,8 +6,8 @@ clientに使うclass
 import os
 from abc import ABCMeta, abstractmethod
 
-import slackbot_settings as conf
 from slack import WebClient
+import slackbot_settings as conf
 
 
 class BaseClient(metaclass=ABCMeta):

--- a/library/clientclass.py
+++ b/library/clientclass.py
@@ -5,8 +5,9 @@ clientに使うclass
 """
 import os
 from abc import ABCMeta, abstractmethod
-from slack import WebClient
+
 import slackbot_settings as conf
+from slack import WebClient
 
 
 class BaseClient(metaclass=ABCMeta):

--- a/library/database.py
+++ b/library/database.py
@@ -3,7 +3,6 @@ DBを操作するためのベースクラス
 """
 
 import psycopg2
-
 import slackbot_settings as conf
 
 

--- a/library/earthquake.py
+++ b/library/earthquake.py
@@ -5,7 +5,8 @@
 """
 
 import json
-from typing import Optional, Any
+from typing import Any, Optional
+
 import requests
 
 

--- a/library/geo.py
+++ b/library/geo.py
@@ -5,10 +5,9 @@ amesh
 """
 
 import json
-from typing import Optional, Dict
+from typing import Dict, Optional
 
 import requests
-
 import slackbot_settings as conf
 
 

--- a/library/vocabularydb.py
+++ b/library/vocabularydb.py
@@ -2,8 +2,8 @@
 パワーワード機能
 """
 
-import psycopg2
 from library.database import Database
+import psycopg2
 
 
 class VocabularyDatabase(Database):

--- a/library/vocabularydb.py
+++ b/library/vocabularydb.py
@@ -3,7 +3,6 @@
 """
 
 import psycopg2
-
 from library.database import Database
 
 

--- a/plugins/analyze.py
+++ b/plugins/analyze.py
@@ -4,8 +4,8 @@
 
 from typing import Callable
 
-import plugins.hato as hato
 from library.clientclass import BaseClient
+import plugins.hato as hato
 
 
 def analyze_message(message: str) -> Callable[[BaseClient], None]:

--- a/plugins/analyze.py
+++ b/plugins/analyze.py
@@ -3,8 +3,9 @@
 """
 
 from typing import Callable
-from library.clientclass import BaseClient
+
 import plugins.hato as hato
+from library.clientclass import BaseClient
 
 
 def analyze_message(message: str) -> Callable[[BaseClient], None]:

--- a/plugins/hato.py
+++ b/plugins/hato.py
@@ -11,9 +11,9 @@ from tempfile import NamedTemporaryFile
 from typing import List
 
 import requests
-import slackbot_settings as conf
 from git import Repo
 from git.exc import InvalidGitRepositoryError
+import slackbot_settings as conf
 from library.clientclass import BaseClient
 from library.earthquake import generate_quake_info_for_slack, get_quake_list
 from library.geo import get_geo_data

--- a/plugins/hato.py
+++ b/plugins/hato.py
@@ -9,18 +9,23 @@ import re
 from logging import getLogger
 from tempfile import NamedTemporaryFile
 from typing import List
+
 import requests
+import slackbot_settings as conf
 from git import Repo
 from git.exc import InvalidGitRepositoryError
-
-import slackbot_settings as conf
-from library.vocabularydb \
-    import get_vocabularys, add_vocabulary, show_vocabulary, delete_vocabulary, show_random_vocabulary
+from library.clientclass import BaseClient
 from library.earthquake import generate_quake_info_for_slack, get_quake_list
-from library.hukidasi import generator
 from library.geo import get_geo_data
 from library.hatokaraage import hato_ha_karaage
-from library.clientclass import BaseClient
+from library.hukidasi import generator
+from library.vocabularydb import (
+    add_vocabulary,
+    delete_vocabulary,
+    get_vocabularys,
+    show_random_vocabulary,
+    show_vocabulary,
+)
 
 logger = getLogger(__name__)
 VERSION = "2.0.2"

--- a/plugins/hato.py
+++ b/plugins/hato.py
@@ -4,28 +4,24 @@
 
 import imghdr
 import json
+from logging import getLogger
 import os
 import re
-from logging import getLogger
 from tempfile import NamedTemporaryFile
 from typing import List
 
-import requests
 from git import Repo
 from git.exc import InvalidGitRepositoryError
-import slackbot_settings as conf
 from library.clientclass import BaseClient
 from library.earthquake import generate_quake_info_for_slack, get_quake_list
 from library.geo import get_geo_data
 from library.hatokaraage import hato_ha_karaage
 from library.hukidasi import generator
-from library.vocabularydb import (
-    add_vocabulary,
-    delete_vocabulary,
-    get_vocabularys,
-    show_random_vocabulary,
-    show_vocabulary,
-)
+from library.vocabularydb import (add_vocabulary, delete_vocabulary,
+                                  get_vocabularys, show_random_vocabulary,
+                                  show_vocabulary)
+import requests
+import slackbot_settings as conf
 
 logger = getLogger(__name__)
 VERSION = "2.0.2"

--- a/run.py
+++ b/run.py
@@ -3,18 +3,18 @@
 """
 BotのMain関数
 """
+from concurrent.futures import ThreadPoolExecutor
 import logging
 import logging.config
 import sys
-from concurrent.futures import ThreadPoolExecutor
 from typing import Callable, List
 
 from flask import Flask, escape, request
-from slackeventsapi import SlackEventAdapter
+from library.clientclass import ApiClient, SlackClient
 import plugins.analyze as analyze
 import plugins.hato as hato
 import slackbot_settings as conf
-from library.clientclass import ApiClient, SlackClient
+from slackeventsapi import SlackEventAdapter
 
 app = Flask(__name__)
 

--- a/run.py
+++ b/run.py
@@ -3,17 +3,18 @@
 """
 BotのMain関数
 """
-import sys
 import logging
 import logging.config
-from typing import Callable, List
+import sys
 from concurrent.futures import ThreadPoolExecutor
-from slackeventsapi import SlackEventAdapter
-from flask import Flask, request, escape
-import slackbot_settings as conf
-import plugins.hato as hato
+from typing import Callable, List
+
 import plugins.analyze as analyze
+import plugins.hato as hato
+import slackbot_settings as conf
+from flask import Flask, request, escape
 from library.clientclass import SlackClient, ApiClient
+from slackeventsapi import SlackEventAdapter
 
 app = Flask(__name__)
 

--- a/run.py
+++ b/run.py
@@ -9,12 +9,12 @@ import sys
 from concurrent.futures import ThreadPoolExecutor
 from typing import Callable, List
 
+from flask import Flask, escape, request
+from slackeventsapi import SlackEventAdapter
 import plugins.analyze as analyze
 import plugins.hato as hato
 import slackbot_settings as conf
-from flask import Flask, request, escape
-from library.clientclass import SlackClient, ApiClient
-from slackeventsapi import SlackEventAdapter
+from library.clientclass import ApiClient, SlackClient
 
 app = Flask(__name__)
 

--- a/slackbot_settings.py
+++ b/slackbot_settings.py
@@ -8,7 +8,7 @@ import os
 import ssl
 import urllib.parse
 
-from dotenv import load_dotenv, find_dotenv
+from dotenv import find_dotenv, load_dotenv
 
 # .envファイルがあれば読み込む。存在しなければ環境変数から読み込む。
 load_dotenv(find_dotenv())

--- a/tests/library/test_geo.py
+++ b/tests/library/test_geo.py
@@ -5,7 +5,6 @@ import json
 import unittest
 
 import requests_mock
-
 import slackbot_settings as conf
 from library.geo import get_geo_data
 

--- a/tests/library/test_geo.py
+++ b/tests/library/test_geo.py
@@ -4,9 +4,9 @@ amesh.pyのテスト
 import json
 import unittest
 
+from library.geo import get_geo_data
 import requests_mock
 import slackbot_settings as conf
-from library.geo import get_geo_data
 
 
 def set_mock(place: str, mocker: requests_mock.Mocker, content=None):

--- a/tests/library/test_hatokaraage.py
+++ b/tests/library/test_hatokaraage.py
@@ -3,6 +3,7 @@
 """
 
 import unittest
+
 from library.hatokaraage import hato_ha_karaage
 
 

--- a/tests/library/test_hukidasi.py
+++ b/tests/library/test_hukidasi.py
@@ -2,8 +2,9 @@
 hukidashiライブラリのテスト
 """
 
-import unittest
 import textwrap
+import unittest
+
 from library.hukidasi import generator
 
 

--- a/tests/plugins/test_analyze.py
+++ b/tests/plugins/test_analyze.py
@@ -4,8 +4,8 @@ analyze.pyのテスト
 
 import unittest
 
-from plugins.analyze import analyze_message
 import plugins.hato as hato
+from plugins.analyze import analyze_message
 from tests.plugins import TestClient
 
 

--- a/tests/plugins/test_analyze.py
+++ b/tests/plugins/test_analyze.py
@@ -4,8 +4,8 @@ analyze.pyのテスト
 
 import unittest
 
-import plugins.hato as hato
 from plugins.analyze import analyze_message
+import plugins.hato as hato
 from tests.plugins import TestClient
 
 

--- a/tests/plugins/test_hato.py
+++ b/tests/plugins/test_hato.py
@@ -3,12 +3,12 @@ hato.pyのテスト
 """
 import json
 import os
-import unittest
 from typing import List
+import unittest
 
+from plugins.hato import altitude, amesh, split_command, yoshiyoshi
 import requests_mock
 import slackbot_settings as conf
-from plugins.hato import altitude, amesh, split_command, yoshiyoshi
 from tests.library.test_geo import set_mock
 from tests.plugins import TestClient
 

--- a/tests/plugins/test_hato.py
+++ b/tests/plugins/test_hato.py
@@ -7,9 +7,8 @@ import unittest
 from typing import List
 
 import requests_mock
-
 import slackbot_settings as conf
-from plugins.hato import split_command, amesh, altitude, yoshiyoshi
+from plugins.hato import altitude, amesh, split_command, yoshiyoshi
 from tests.library.test_geo import set_mock
 from tests.plugins import TestClient
 

--- a/wait_db.py
+++ b/wait_db.py
@@ -3,8 +3,8 @@ DBが起動するまで待機する
 """
 from time import sleep
 
-import psycopg2
 from library.database import Database
+import psycopg2
 
 
 def wait_db() -> None:

--- a/wait_db.py
+++ b/wait_db.py
@@ -4,7 +4,6 @@ DBが起動するまで待機する
 from time import sleep
 
 import psycopg2
-
 from library.database import Database
 
 


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/runs/2158092545#step:11:606

上記のsuper-linterのエラーはflake8起因であり、flake8 3.9.0で修正されています: https://bugs.archlinux.org/task/70021
そして、こちらのバージョンはsuper-linter v3.15.5で反映されているようなので ( https://github.com/github/super-linter/pull/1365 )、super-linterをアップデートします。