### PR TITLE
Update super-linter

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -376,7 +376,7 @@ jobs:
         run: cp -r ${{ env.venv_path }} /home/runner/work/_temp/_github_workflow/.venv
 
       - name: Lint files
-        uses: docker://github/super-linter:v3.10.0
+        uses: docker://github/super-linter:v3.15.5
         env:
           VALIDATE_ALL_CODEBASE: true
           VALIDATE_PYTHON_BLACK: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # バージョン情報に表示する commit hash を埋め込む
 FROM alpine:3.13.2 AS commit-hash
-COPY . .
+COPY . /
 RUN apk add --no-cache -U git
 RUN sed -i "s/^\(GIT_COMMIT_HASH = \).*\$/\1'$(git rev-parse HEAD)'/" slackbot_settings.py
 


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/runs/2158092545#step:11:606

上記のsuper-linterのエラーはflake8起因であり、flake8 3.9.0で修正されています: https://bugs.archlinux.org/task/70021
そして、こちらのバージョンはsuper-linter v3.15.5で反映されているようなので ( https://github.com/github/super-linter/pull/1365 )、super-linterをアップデートします。