### PR TITLE
dependabotがCIを回した場合でもwrite系のGitHub APIが実行できるようにする

### DIFF
--- a/.github/workflows/pr-check-yarn.yml
+++ b/.github/workflows/pr-check-yarn.yml
@@ -6,11 +6,16 @@ on:
     paths:
       - "package.json"
       - "yarn.lock"
+  pull_request_target:
+    paths:
+      - "package.json"
+      - "yarn.lock"
 
 jobs:
   # package.jsonかyarn.lockに差分があれば、package.jsonからyarn.lockを作り出す
   pr-check-yarn:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
     strategy:
       matrix:
         node-version: [14.x]

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -3,6 +3,7 @@ name: pr-test
 # pull_requestで何かあった時に起動する
 on:
   pull_request:
+  pull_request_target:
 
 env:
   WORKON_HOME: /tmp/.venv
@@ -11,6 +12,7 @@ jobs:
   # PRが来たらformatをかけてみて、差分があればPRを作って、エラーで落ちるjob
   pr-format:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
     strategy:
       matrix:
         python-version: [3.9]
@@ -165,12 +167,19 @@ jobs:
   # 型ヒントのチェックを行う
   pr-type-hint:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
     strategy:
       matrix:
         python-version: [3.9, 3.8]
 
     steps:
       - uses: actions/checkout@v2
+        if: (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]')
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          submodules: "recursive"
+      - uses: actions/checkout@v2
+        if: (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
         with:
           submodules: "recursive"
       - name: Set up Python ${{ matrix.python-version }}
@@ -211,12 +220,20 @@ jobs:
   # ここではチェックは落ちない
   pr-lint:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
     strategy:
       matrix:
         python-version: [3.9]
 
     steps:
       - uses: actions/checkout@v2
+        if: (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]')
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          submodules: "recursive"
+          fetch-depth: 0
+      - uses: actions/checkout@v2
+        if: (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
         with:
           submodules: "recursive"
           fetch-depth: 0
@@ -311,12 +328,20 @@ jobs:
 
   pr-super-lint:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
     strategy:
       matrix:
         python-version: [3.9]
 
     steps:
       - uses: actions/checkout@v2
+        if: (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]')
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          submodules: "recursive"
+          fetch-depth: 0
+      - uses: actions/checkout@v2
+        if: (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
         with:
           submodules: "recursive"
           fetch-depth: 0

--- a/.github/workflows/pr-textlint.yml
+++ b/.github/workflows/pr-textlint.yml
@@ -3,17 +3,27 @@ name: pr-textlint
 # pull_requestで何かあった時に起動する
 on:
   pull_request:
+  pull_request_target:
 
 jobs:
   # textlintをかけ、結果をPRにコメントとして表示する。
   lint:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
     strategy:
       matrix:
         node-version: [14.x]
 
     steps:
       - uses: actions/checkout@v2
+        if: (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]')
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          # ここでsubmodule持ってくるとdetached headにcommitして死ぬ
+          # submodule: 'recursive'
+          fetch-depth: 0
+      - uses: actions/checkout@v2
+        if: (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
         with:
           # ここでsubmodule持ってくるとdetached headにcommitして死ぬ
           # submodule: 'recursive'
@@ -98,13 +108,21 @@ jobs:
   # PRが来たらtextlintをかけてみて、差分があればPRを作って、エラーで落ちるjob
   format:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: ((github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')) && github.event.pull_request.head.repo.full_name == github.repository
     strategy:
       matrix:
         node-version: [14.x]
 
     steps:
       - uses: actions/checkout@v2
+        if: (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]')
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          # ここでsubmodule持ってくるとdetached headにcommitして死ぬ
+          # submodule: 'recursive'
+          fetch-depth: 0
+      - uses: actions/checkout@v2
+        if: (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
         with:
           # ここでsubmodule持ってくるとdetached headにcommitして死ぬ
           # submodule: 'recursive'


### PR DESCRIPTION
dependabotがCIを回した場合、write系のGitHub API (PRへのコメント等) が実行できずCIが失敗します。
そのため、dependabotがCIを実行する場合に限り、 `pull_request` トリガーの代わりに `pull_request_target` トリガーを使用します。

参考: https://simple-minds-think-alike.hatenablog.com/entry/dependabot-pull-request-fail