### PR TITLE
versionコマンド修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,13 +13,13 @@ COPY Pipfile Pipfile
 # 実行時に必要なパッケージ (グループ名: .used-packages)
 # * postgresql-libs: psycopg2を使用する際に必要
 # * libjpeg-turbo: Pillowを使用する際に必要
+# * git: gitpythonを使用する際に必要
 #
 # Pythonライブラリのインストール時に必要なパッケージ (グループ名: .build-deps, Pythonライブラリインストール後にアンインストール)
 # * jpeg-dev, zlib-dev: Pillowのインストールの際に必要
 # * gcc, musl-dev, postgresql-dev: psycopg2のインストールの際に必要
-# * git: Pythonライブラリのインストールの際に必要
-RUN apk add --no-cache -t .used-packages postgresql-libs libjpeg-turbo && \
-    apk add --no-cache -t .build-deps jpeg-dev zlib-dev gcc musl-dev postgresql-dev git && \
+RUN apk add --no-cache -t .used-packages postgresql-libs libjpeg-turbo git && \
+    apk add --no-cache -t .build-deps jpeg-dev zlib-dev gcc musl-dev postgresql-dev && \
     pip install pipenv==2020.8.13 --no-cache-dir && \
     pipenv install --system --skip-lock && \
     pip uninstall -y pipenv virtualenv && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,13 +13,13 @@ COPY Pipfile Pipfile
 # 実行時に必要なパッケージ (グループ名: .used-packages)
 # * postgresql-libs: psycopg2を使用する際に必要
 # * libjpeg-turbo: Pillowを使用する際に必要
-# * git: gitpythonを使用する際に必要
 #
 # Pythonライブラリのインストール時に必要なパッケージ (グループ名: .build-deps, Pythonライブラリインストール後にアンインストール)
 # * jpeg-dev, zlib-dev: Pillowのインストールの際に必要
 # * gcc, musl-dev, postgresql-dev: psycopg2のインストールの際に必要
-RUN apk add --no-cache -t .used-packages postgresql-libs libjpeg-turbo git && \
-    apk add --no-cache -t .build-deps jpeg-dev zlib-dev gcc musl-dev postgresql-dev && \
+# * git: Pythonライブラリのインストールの際に必要
+RUN apk add --no-cache -t .used-packages postgresql-libs libjpeg-turbo && \
+    apk add --no-cache -t .build-deps jpeg-dev zlib-dev gcc musl-dev postgresql-dev git && \
     pip install pipenv==2020.8.13 --no-cache-dir && \
     pipenv install --system --skip-lock && \
     pip uninstall -y pipenv virtualenv && \

--- a/plugins/hato.py
+++ b/plugins/hato.py
@@ -11,7 +11,7 @@ from tempfile import NamedTemporaryFile
 from typing import List
 import requests
 from git import Repo
-from git.exc import InvalidGitRepositoryError
+from git.exc import InvalidGitRepositoryError, GitCommandNotFound
 
 import slackbot_settings as conf
 from library.vocabularydb \
@@ -249,13 +249,13 @@ def version(client: BaseClient):
     str_ver = "バージョン情報\n```" \
               f"Version {VERSION}"
 
-    if conf.GIT_COMMIT_HASH:
+    if conf.GIT_COMMIT_HASH is not None and conf.GIT_COMMIT_HASH != 'None':
         str_ver += f" (Commit {conf.GIT_COMMIT_HASH[:7]})"
     else:
         try:
             repo = Repo()
             str_ver += f" (Commit {repo.head.commit.hexsha[:7]})"
-        except InvalidGitRepositoryError:
+        except (InvalidGitRepositoryError, GitCommandNotFound):
             pass
 
     str_ver += "\n" \

--- a/plugins/hato.py
+++ b/plugins/hato.py
@@ -249,7 +249,7 @@ def version(client: BaseClient):
     str_ver = "バージョン情報\n```" \
               f"Version {VERSION}"
 
-    if conf.GIT_COMMIT_HASH is not None and conf.GIT_COMMIT_HASH != 'None':
+    if conf.GIT_COMMIT_HASH:
         str_ver += f" (Commit {conf.GIT_COMMIT_HASH[:7]})"
     else:
         try:

--- a/plugins/hato.py
+++ b/plugins/hato.py
@@ -11,7 +11,7 @@ from tempfile import NamedTemporaryFile
 from typing import List
 import requests
 from git import Repo
-from git.exc import InvalidGitRepositoryError
+from git.exc import InvalidGitRepositoryError, GitCommandNotFound
 
 import slackbot_settings as conf
 from library.vocabularydb \
@@ -255,7 +255,7 @@ def version(client: BaseClient):
         try:
             repo = Repo()
             str_ver += f" (Commit {repo.head.commit.hexsha[:7]})"
-        except InvalidGitRepositoryError:
+        except (InvalidGitRepositoryError, GitCommandNotFound):
             pass
 
     str_ver += "\n" \

--- a/plugins/hato.py
+++ b/plugins/hato.py
@@ -11,7 +11,7 @@ from tempfile import NamedTemporaryFile
 from typing import List
 import requests
 from git import Repo
-from git.exc import InvalidGitRepositoryError, GitCommandNotFound
+from git.exc import InvalidGitRepositoryError
 
 import slackbot_settings as conf
 from library.vocabularydb \
@@ -255,7 +255,7 @@ def version(client: BaseClient):
         try:
             repo = Repo()
             str_ver += f" (Commit {repo.head.commit.hexsha[:7]})"
-        except (InvalidGitRepositoryError, GitCommandNotFound):
+        except InvalidGitRepositoryError:
             pass
 
     str_ver += "\n" \

--- a/slackbot_settings.py
+++ b/slackbot_settings.py
@@ -34,4 +34,4 @@ YAHOO_API_TOKEN = str(os.environ['YAHOO_API_TOKEN'])
 DEFAULT_REPLY = "使い方がわからない時は `help` とメンションするっぽ!"
 PLUGINS = ['plugins']
 
-GIT_COMMIT_HASH = str(os.environ.get('GIT_COMMIT_HASH'))
+GIT_COMMIT_HASH = os.environ.get('GIT_COMMIT_HASH')


### PR DESCRIPTION
`slackbot_settings.py` の `GIT_COMMIT_HASH` では環境変数からコミットハッシュを取得していますが、その際strへの変換を行っています。
その結果、 `None` の場合も`"None"` というstrに変換され、以下のif文が意図通り動かない状態になっていました。
https://github.com/dev-hato/hato-bot/blob/bb5b87a18aed788f3b05e384d40c41a4464caa31/plugins/hato.py#L252
したがって、strへの変換をなくします。

また、docker-composeを使用した場合、`slack_settings.py` がローカル環境の内容に差し替えられるため (以下参照)、gitpythonでコミットハッシュを取得しようとします。
https://github.com/dev-hato/hato-bot/blob/5590cca9ac4bd0b971cc6877631807b47a7cebbb/setup/docker-compose.yml#L23-L24
しかし、gitコマンドがないことが原因で `GitCommandNotFound` が発生するため、その際の対処も追加しています。
※docker-composeを使用した場合はコミットハッシュが表示されないのを正としています。