### PR TITLE
10min減算の処理を修正

### DIFF
--- a/run.py
+++ b/run.py
@@ -72,7 +72,8 @@ def on_app_mention(event_data):
             return
 
         cursor.execute(
-            "DELETE FROM slack_client_msg_id WHERE created_at < CURRENT_TIMESTAMP - interval '10 minutes'",
+            "DELETE FROM slack_client_msg_id "
+            "WHERE created_at < CURRENT_TIMESTAMP - interval '10 minutes'",
             (client_msg_id,))
         cursor.execute(
             'INSERT INTO slack_client_msg_id(client_msg_id, created_at) '

--- a/run.py
+++ b/run.py
@@ -72,7 +72,7 @@ def on_app_mention(event_data):
             return
 
         cursor.execute(
-            "DELETE FROM slack_client_msg_id WHERE created_at < CURRENT_TIMESTAMP - '00:10:00'",
+            "DELETE FROM slack_client_msg_id WHERE created_at < CURRENT_TIMESTAMP - interval '10 minutes'",
             (client_msg_id,))
         cursor.execute(
             'INSERT INTO slack_client_msg_id(client_msg_id, created_at) '


### PR DESCRIPTION
fix for #620 

上記のPRを適用後、botが以下のエラーを吐くようになった。
```
hato-bot_1  | psycopg2.errors.InvalidDatetimeFormat: invalid input syntax for type timestamp with time zone: "00:10:00"
```

timestampのフォーマットがおかしいのではないかと考え、intervalを使うように修正した。