### PR TITLE
XSS対策

### DIFF
--- a/run.py
+++ b/run.py
@@ -9,7 +9,7 @@ import logging.config
 from typing import Callable, List
 from concurrent.futures import ThreadPoolExecutor
 from slackeventsapi import SlackEventAdapter
-from flask import Flask, request
+from flask import Flask, request, escape
 import slackbot_settings as conf
 import plugins.hato as hato
 import plugins.analyze as analyze
@@ -128,7 +128,7 @@ def healthcheck_app():
     curl -XPOST -d '{"message": "鳩"}' \
         -H "Content-Type: application/json" http://localhost:3000/healthcheck
     """
-    msg = request.json['message']
+    msg = escape(request.json['message'])
     client = ApiClient()
     client.post(f'コマンド: {msg}')
     analyze.analyze_message(msg)(client)


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/security/code-scanning/1?query=ref%3Arefs%2Fheads%2Fdevelop

```
Directly writing user input (for example, an HTTP request parameter) to a webpage without properly sanitizing the input first, allows for a cross-site scripting vulnerability.
```

APIの動作確認用のエンドポイントにおいて、入力値のエスケープを行うようにします。