### PR TITLE
pylintアップデート

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
-pylint = "==2.8.3"
+pylint = "==2.9.3"
 autopep8 = "==1.5.7"
 requests-mock = "*"
 

--- a/plugins/analyze.py
+++ b/plugins/analyze.py
@@ -4,7 +4,7 @@
 
 from typing import Callable
 from library.clientclass import BaseClient
-import plugins.hato as hato
+from plugins import hato
 
 
 def analyze_message(message: str) -> Callable[[BaseClient], None]:

--- a/run.py
+++ b/run.py
@@ -11,8 +11,8 @@ from concurrent.futures import ThreadPoolExecutor
 from slackeventsapi import SlackEventAdapter
 from flask import Flask, request, escape
 import slackbot_settings as conf
-import plugins.hato as hato
-import plugins.analyze as analyze
+from plugins import hato
+from plugins import analyze
 from library.clientclass import SlackClient, ApiClient
 from library.database import Database
 

--- a/tests/plugins/test_analyze.py
+++ b/tests/plugins/test_analyze.py
@@ -5,7 +5,7 @@ analyze.pyのテスト
 import unittest
 
 from plugins.analyze import analyze_message
-import plugins.hato as hato
+from plugins import hato
 from tests.plugins import TestClient
 
 


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/pull/648 をベースにpylintをアップデートします。

https://github.com/dev-hato/hato-bot/pull/648#issuecomment-872641752 の指摘を修正しています。

```
************* Module tests.plugins.test_analyze
tests/plugins/test_analyze.py:8:0: R0402: Use 'from plugins import hato' instead (consider-using-from-import)
************* Module plugins.analyze
plugins/analyze.py:7:0: R0402: Use 'from plugins import hato' instead (consider-using-from-import)
************* Module run
run.py:14:0: R0402: Use 'from plugins import hato' instead (consider-using-from-import)
run.py:15:0: R0402: Use 'from plugins import analyze' instead (consider-using-from-import)
```