### PR TITLE
super-linterアップデート

### DIFF
--- a/.github/workflows/pr-check-yarn.yml
+++ b/.github/workflows/pr-check-yarn.yml
@@ -38,27 +38,32 @@ jobs:
           echo "::set-output name=result::$result"
       # 差分があったときは、コミットを作りpushする
       - name: Push
+        env:
+          HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.diff.outputs.result != '' }}
         run: |
           git config user.name "hatohakaraage"
           git config user.email "hatohakaraage@example.com"
           git add -u
           git commit -m "鳩は唐揚げ！(自動で直してあげたよ！)"
-          git push -f https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git HEAD:refs/heads/yarn-${{github.event.pull_request.head.ref}}
+          git push -f https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git "HEAD:refs/heads/yarn-${HEAD_REF}"
       # pushしたブランチでPRを作る
       - name: Create PullRequest
         uses: actions/github-script@v4.1
+        env:
+          HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.diff.outputs.result != '' }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
+            const HEAD_REF = process.env["HEAD_REF"]
             const common_params = {
               owner: context.repo.owner,
               repo: context.repo.repo
             }
             const pull_params = {
-              head: "${{github.event.pull_request.head.repo.owner.login}}:yarn-${{github.event.pull_request.head.ref}}",
-              base: "${{github.event.pull_request.head.ref}}",
+              head: "${{github.event.pull_request.head.repo.owner.login}}:yarn-" + HEAD_REF,
+              base: HEAD_REF,
               ...common_params
             }
             const pulls_list_params = {
@@ -93,18 +98,21 @@ jobs:
       # 既にpackage.json, yarn.lock修正のPRがある状態で、手動でpackage.json, yarn.lockを修正した場合、修正のPRを閉じる
       - name: Close PullRequest
         uses: actions/github-script@v4.1
+        env:
+          HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.diff.outputs.result == '' }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const head_name = "yarn-${{github.event.pull_request.head.ref}}"
+            const HEAD_REF = process.env["HEAD_REF"]
+            const head_name = "yarn-" + HEAD_REF
             const common_params = {
               owner: context.repo.owner,
               repo: context.repo.repo
             }
             const pulls_list_params = {
               head: "${{github.event.pull_request.head.repo.owner.login}}:" + head_name,
-              base: "${{github.event.pull_request.head.ref}}",
+              base: HEAD_REF,
               state: "open",
               ...common_params
             }

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -231,7 +231,7 @@ jobs:
         run: cp -r ${{ env.venv_path }} /home/runner/work/_temp/_github_workflow/.venv
 
       - name: Lint files
-        uses: github/super-linter@v4.6.2
+        uses: github/super-linter@v4.7.1
         env:
           VALIDATE_ALL_CODEBASE: true
           VALIDATE_PYTHON_BLACK: false

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -66,27 +66,32 @@ jobs:
           git diff
       # 差分があったときは、コミットを作りpushする
       - name: Push
+        env:
+          HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.format.outcome == 'failure' }}
         run: |
           git config user.name "hatohakaraage"
           git config user.email "hatohakaraage@example.com"
           git add -u
           git commit -m "鳩は唐揚げ！(自動で直してあげたよ！)"
-          git push -f https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git HEAD:refs/heads/fix-format-${{github.event.pull_request.head.ref}}
+          git push -f https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git "HEAD:refs/heads/fix-format-${HEAD_REF}"
       # pushしたブランチでPRを作る
       - name: Create PullRequest
         uses: actions/github-script@v4.1
+        env:
+          HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.format.outcome == 'failure' }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
+            const HEAD_REF = process.env["HEAD_REF"]
             const common_params = {
               owner: context.repo.owner,
               repo: context.repo.repo
             }
             const pull_params = {
-              head: "dev-hato:fix-format-${{github.event.pull_request.head.ref}}",
-              base: "${{github.event.pull_request.head.ref}}",
+              head: "dev-hato:fix-format-" + HEAD_REF,
+              base: HEAD_REF,
               ...common_params
             }
             const pulls_list_params = {
@@ -121,18 +126,21 @@ jobs:
       # 既にformat修正のPRがある状態で、手動でformatを修正した場合、format修正のPRを閉じる
       - name: Close PullRequest
         uses: actions/github-script@v4.1
+        env:
+          HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.format.outcome != 'failure' }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const head_name = "fix-format-${{github.event.pull_request.head.ref}}"
+            const HEAD_REF = process.env["HEAD_REF"]
+            const head_name = "fix-format-" + HEAD_REF
             const common_params = {
               owner: context.repo.owner,
               repo: context.repo.repo
             }
             const pulls_list_params = {
               head: "dev-hato:" + head_name,
-              base: "${{github.event.pull_request.head.ref}}",
+              base: HEAD_REF,
               state: "open",
               ...common_params
             }

--- a/.github/workflows/pr-textlint.yml
+++ b/.github/workflows/pr-textlint.yml
@@ -141,27 +141,32 @@ jobs:
           echo "::set-output name=diff::$(git diff)"
       # 差分があったときは、コミットを作りpushする
       - name: Push
+        env:
+          HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ steps.show_diff.outputs.diff != '' }}
         run: |
           git config user.name "hatohakaraage"
           git config user.email "hatohakaraage@example.com"
           git add -u
           git commit -m "鳩は唐揚げ！(自動で直してあげたよ！)"
-          git push -f https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git HEAD:refs/heads/fix-text-${{github.event.pull_request.head.ref}}
+          git push -f https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git "HEAD:refs/heads/fix-text-${HEAD_REF}"
       # pushしたブランチでPRを作る
       - name: Create PullRequest
         uses: actions/github-script@v4.1
+        env:
+          HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ steps.show_diff.outputs.diff != '' }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
+            const HEAD_REF = process.env["HEAD_REF"]
             const common_params = {
               owner: context.repo.owner,
               repo: context.repo.repo
             }
             const pull_params = {
-              head: "dev-hato:fix-text-${{github.event.pull_request.head.ref}}",
-              base: "${{github.event.pull_request.head.ref}}",
+              head: "dev-hato:fix-text-" + HEAD_REF,
+              base: HEAD_REF,
               ...common_params
             }
             const pulls_list_params = {
@@ -196,18 +201,21 @@ jobs:
       # 既にformat修正のPRがある状態で、手動でformatを修正した場合、format修正のPRを閉じる
       - name: Close PullRequest
         uses: actions/github-script@v4.1
+        env:
+          HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ steps.show_diff.outputs.diff == '' }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const head_name = "fix-text-${{github.event.pull_request.head.ref}}"
+            const HEAD_REF = process.env["HEAD_REF"]
+            const head_name = "fix-text-" + HEAD_REF
             const common_params = {
               owner: context.repo.owner,
               repo: context.repo.repo
             }
             const pulls_list_params = {
               head: "dev-hato:" + head_name,
-              base: "${{github.event.pull_request.head.ref}}",
+              base: HEAD_REF,
               state: "open",
               ...common_params
             }

--- a/create_env.py
+++ b/create_env.py
@@ -8,7 +8,7 @@ from library.database import Database
 def create_table() -> None:
     """テーブルを作成する"""
 
-    with Database() as _db, open('setup/pgsql-init/02_init.sql') as init_sql:
+    with Database() as _db, open('setup/pgsql-init/02_init.sql', encoding='UTF-8') as init_sql:
         sql = ''
         for line in init_sql.readlines():
             sql += line


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/pull/682 をベースにsuper-linterをアップデートします。

`github.event.pull_request.head.ref` を直接コード内に埋め込むとインジェクション攻撃される危険があるため、環境変数を経由して参照するようにしています。  
参考: https://securitylab.github.com/research/github-actions-untrusted-input/


```
create_env.py:11:28: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
```

また、上記への対処として `open` でエンコーディングを指定しています。