### PR TITLE
CI pr-check-yarn を全てのPRに対して動作させる

### DIFF
--- a/.github/workflows/pr-check-yarn.yml
+++ b/.github/workflows/pr-check-yarn.yml
@@ -1,11 +1,7 @@
 name: pr-check-yarn
 
-# package.jsonかyarn.lockに差分があるPRに反応して起動する
 on:
   pull_request:
-    paths:
-      - "package.json"
-      - "yarn.lock"
 
 jobs:
   # package.jsonかyarn.lockに差分があれば、package.jsonからyarn.lockを作り出す


### PR DESCRIPTION
以下のような事象が発生するため、CI `pr-check-yarn` を全てのPRに対して動作させるようにします。

1. package.jsonかyarn.lockに差分がある状態でPRを立てる
2. CI `pr-check-yarn` が実行され、修正PRが立てられる
3. 手動で修正した結果、package.jsonかyarn.lockの差分がなくなる
4. CI `pr-check-yarn` が実行されないので、修正PRが立ったままになる