### PR TITLE
早期returnしている箇所を別のstepに分離・ページネーション対応

### DIFF
--- a/.github/workflows/pr-check-yarn.yml
+++ b/.github/workflows/pr-check-yarn.yml
@@ -61,7 +61,7 @@ jobs:
               state: "open"
             }
             console.log("call pulls.list:", pulls_list_params)
-            const pulls = (await github.pulls.list(pulls_list_params)).data
+            const pulls = await github.paginate(github.pulls.list, pulls_list_params)
             return pulls.length
       # pushしたブランチでPRを作る
       - name: Create PullRequest
@@ -121,7 +121,7 @@ jobs:
               ...common_params
             }
             console.log("call pulls.list:", pulls_list_params)
-            const pulls = (await github.pulls.list(pulls_list_params)).data
+            const pulls = await github.paginate(github.pulls.list, pulls_list_params)
 
             for (const pull of pulls) {
               const pulls_update_params = {

--- a/.github/workflows/pr-check-yarn.yml
+++ b/.github/workflows/pr-check-yarn.yml
@@ -43,7 +43,7 @@ jobs:
           git add -u
           git commit -m "鳩は唐揚げ！(自動で直してあげたよ！)"
           git push -f https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git "HEAD:refs/heads/yarn-${HEAD_REF}"
-      - name: Get pull requests
+      - name: Get PullRequests
         uses: actions/github-script@v4.1
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}

--- a/.github/workflows/pr-check-yarn.yml
+++ b/.github/workflows/pr-check-yarn.yml
@@ -43,52 +43,59 @@ jobs:
           git add -u
           git commit -m "鳩は唐揚げ！(自動で直してあげたよ！)"
           git push -f https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git "HEAD:refs/heads/yarn-${HEAD_REF}"
+      - name: Get pull requests
+        uses: actions/github-script@v4.1
+        env:
+          HEAD_REF: ${{github.event.pull_request.head.ref}}
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.diff.outputs.result != '' }}
+        id: get_pull_requests
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const HEAD_REF = process.env["HEAD_REF"]
+            const pulls_list_params = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: "${{github.event.pull_request.head.repo.owner.login}}:yarn-" + HEAD_REF,
+              base: HEAD_REF,
+              state: "open"
+            }
+            console.log("call pulls.list:", pulls_list_params)
+            const pulls = (await github.pulls.list(pulls_list_params)).data
+            return pulls.length
       # pushしたブランチでPRを作る
       - name: Create PullRequest
         uses: actions/github-script@v4.1
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.diff.outputs.result != '' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.diff.outputs.result != '' && steps.get_pull_requests.outputs.result == 0 }}
+        id: create_pull_request
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const HEAD_REF = process.env["HEAD_REF"]
-            const common_params = {
+            const pulls_create_params = {
               owner: context.repo.owner,
-              repo: context.repo.repo
-            }
-            const pull_params = {
+              repo: context.repo.repo,
               head: "${{github.event.pull_request.head.repo.owner.login}}:yarn-" + HEAD_REF,
               base: HEAD_REF,
-              ...common_params
-            }
-            const pulls_list_params = {
-              state: "open",
-              ...pull_params
-            }
-            console.log("call pulls.list:", pulls_list_params)
-            const pulls = (await github.pulls.list(pulls_list_params)).data
-
-            if (0 < pulls.length) {
-              return
-            }
-
-            const pulls_create_params = {
               title: "package.jsonやyarn.lockが更新されたので直してあげたよ！PRをマージしてね！ #${{github.event.pull_request.number}}",
-              body: "鳩の唐揚げおいしい！😋😋😋 #${{github.event.pull_request.number}}",
-              ...pull_params
+              body: "鳩の唐揚げおいしい！😋😋😋 #${{github.event.pull_request.number}}"
             }
             console.log("call pulls.create:", pulls_create_params)
             const create_pull_res = (await github.pulls.create(pulls_create_params)).data
-
-            if ("${{github.event.pull_request.user.login}}" === "dependabot[bot]") {
-              return
-            }
-
+            return create_pull_res.number
+      - name: Assign a user
+        uses: actions/github-script@v4.1
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.diff.outputs.result != '' && steps.get_pull_requests.outputs.result == 0 && github.event.pull_request.user.login != 'dependabot[bot]' }}
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
             const issues_add_assignees_params = {
-              issue_number: create_pull_res.number,
-              assignees: ["${{github.event.pull_request.user.login}}"],
-              ...common_params
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{steps.create_pull_request.outputs.result}},
+              assignees: ["${{github.event.pull_request.user.login}}"]
             }
             console.log("call issues.addAssignees:", issues_add_assignees_params)
             await github.issues.addAssignees(issues_add_assignees_params)

--- a/.github/workflows/pr-merge-develop-hato-bot.yml
+++ b/.github/workflows/pr-merge-develop-hato-bot.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Get pull requests
+      - name: Get PullRequests
         uses: actions/github-script@v4.1
         id: get_pull_requests
         with:

--- a/.github/workflows/pr-merge-develop-hato-bot.yml
+++ b/.github/workflows/pr-merge-develop-hato-bot.yml
@@ -32,7 +32,7 @@ jobs:
               state: "open"
             }
             console.log("call pulls.list:", pulls_list_params)
-            const pulls = (await github.pulls.list(pulls_list_params)).data
+            const pulls = await github.paginate(github.pulls.list, pulls_list_params)
             return pulls.length
       - name: Create PullRequest
         uses: actions/github-script@v4.1

--- a/.github/workflows/pr-merge-develop-hato-bot.yml
+++ b/.github/workflows/pr-merge-develop-hato-bot.yml
@@ -18,8 +18,25 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: Get pull requests
+        uses: actions/github-script@v4.1
+        id: get_pull_requests
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const pulls_list_params = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: "dev-hato:master",
+              base: "develop",
+              state: "open"
+            }
+            console.log("call pulls.list:", pulls_list_params)
+            const pulls = (await github.pulls.list(pulls_list_params)).data
+            return pulls.length
       - name: Create PullRequest
         uses: actions/github-script@v4.1
+        if: ${{ steps.get_pull_requests.outputs.result == 0 }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -27,26 +44,12 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo
             }
-            const pull_params = {
+            const pulls_create_params = {
               head: "dev-hato:master",
               base: "develop",
-              ...common_params
-            }
-            const pulls_list_params = {
-              state: "open",
-              ...pull_params
-            }
-            console.log("call pulls.list:", pulls_list_params)
-            const pulls = (await github.pulls.list(pulls_list_params)).data
-
-            if (0 < pulls.length) {
-              return
-            }
-
-            const pulls_create_params = {
               title: "master -> develop",
               body: "鳩の歴史は同期される\ndevelopに新たなコミットがpushされる前にマージしてね！",
-              ...pull_params
+              ...common_params
             }
             console.log("call pulls.create:", pulls_create_params)
             const create_pull_res = (await github.pulls.create(pulls_create_params)).data

--- a/.github/workflows/pr-release-hato-bot.yml
+++ b/.github/workflows/pr-release-hato-bot.yml
@@ -40,7 +40,7 @@ jobs:
               state: "open"
             }
             console.log("call pulls.list:", pulls_list_params)
-            const pulls = (await github.pulls.list(pulls_list_params)).data
+            const pulls = await github.paginate(github.pulls.list, pulls_list_params)
             return pulls.length
       - name: Create PullRequest
         uses: actions/github-script@v4.1

--- a/.github/workflows/pr-release-hato-bot.yml
+++ b/.github/workflows/pr-release-hato-bot.yml
@@ -25,7 +25,7 @@ jobs:
           result="${result//$'\n'/'%0A'}"
           result="${result//$'\r'/'%0D'}"
           echo "::set-output name=result::${result}"
-      - name: Get pull requests
+      - name: Get PullRequests
         uses: actions/github-script@v4.1
         if: ${{ steps.get_diff.outputs.result != '' }}
         id: get_pull_requests

--- a/.github/workflows/pr-release-hato-bot.yml
+++ b/.github/workflows/pr-release-hato-bot.yml
@@ -25,9 +25,26 @@ jobs:
           result="${result//$'\n'/'%0A'}"
           result="${result//$'\r'/'%0D'}"
           echo "::set-output name=result::${result}"
-      - name: Create PullRequest
+      - name: Get pull requests
         uses: actions/github-script@v4.1
         if: ${{ steps.get_diff.outputs.result != '' }}
+        id: get_pull_requests
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const pulls_list_params = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: "dev-hato:develop",
+              base: "master",
+              state: "open"
+            }
+            console.log("call pulls.list:", pulls_list_params)
+            const pulls = (await github.pulls.list(pulls_list_params)).data
+            return pulls.length
+      - name: Create PullRequest
+        uses: actions/github-script@v4.1
+        if: ${{ steps.get_diff.outputs.result != '' && steps.get_pull_requests.outputs.result == 0 }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -35,27 +52,13 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo
             }
-            const pull_params = {
+            const pulls_create_params = {
               head: "dev-hato:develop",
               base: "master",
-              ...common_params
-            }
-            const pulls_list_params = {
-              state: "open",
-              ...pull_params
-            }
-            console.log("call pulls.list:", pulls_list_params)
-            const pulls = (await github.pulls.list(pulls_list_params)).data
-
-            if (0 < pulls.length) {
-              return
-            }
-
-            const pulls_create_params = {
               title: "リリース",
               body: "鳩は唐揚げになるため、片栗粉へ飛び込む",
               draft: true,
-              ...pull_params
+              ...common_params
             }
             console.log("call pulls.create:", pulls_create_params)
             const create_pull_res = (await github.pulls.create(pulls_create_params)).data

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -93,7 +93,7 @@ jobs:
               state: "open"
             }
             console.log("call pulls.list:", pulls_list_params)
-            const pulls = (await github.pulls.list(pulls_list_params)).data
+            const pulls = await github.paginate(github.pulls.list, pulls_list_params)
             return pulls.length
       # pushしたブランチでPRを作る
       - name: Create PullRequest
@@ -154,7 +154,7 @@ jobs:
               ...common_params
             }
             console.log("call pulls.list:", pulls_list_params)
-            const pulls = (await github.pulls.list(pulls_list_params)).data
+            const pulls = await github.paginate(github.pulls.list, pulls_list_params)
 
             for(const data of pulls) {
               const pulls_update_params = {

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -75,7 +75,7 @@ jobs:
           git add -u
           git commit -m "鳩は唐揚げ！(自動で直してあげたよ！)"
           git push -f https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git "HEAD:refs/heads/fix-format-${HEAD_REF}"
-      - name: Get pull requests
+      - name: Get PullRequests
         uses: actions/github-script@v4.1
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -75,50 +75,58 @@ jobs:
           git add -u
           git commit -m "鳩は唐揚げ！(自動で直してあげたよ！)"
           git push -f https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git "HEAD:refs/heads/fix-format-${HEAD_REF}"
+      - name: Get pull requests
+        uses: actions/github-script@v4.1
+        env:
+          HEAD_REF: ${{github.event.pull_request.head.ref}}
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.format.outcome == 'failure' }}
+        id: get_pull_requests
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const HEAD_REF = process.env["HEAD_REF"]
+            const pulls_list_params = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: "dev-hato:fix-format-" + HEAD_REF,
+              base: HEAD_REF,
+              state: "open"
+            }
+            console.log("call pulls.list:", pulls_list_params)
+            const pulls = (await github.pulls.list(pulls_list_params)).data
+            return pulls.length
       # pushしたブランチでPRを作る
       - name: Create PullRequest
         uses: actions/github-script@v4.1
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.format.outcome == 'failure' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.format.outcome == 'failure' && steps.get_pull_requests.outputs.result == 0 }}
+        id: create_pull_request
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const HEAD_REF = process.env["HEAD_REF"]
-            const common_params = {
+            const pulls_create_params = {
               owner: context.repo.owner,
-              repo: context.repo.repo
-            }
-            const pull_params = {
+              repo: context.repo.repo,
               head: "dev-hato:fix-format-" + HEAD_REF,
               base: HEAD_REF,
-              ...common_params
-            }
-            const pulls_list_params = {
-              state: "open",
-              ...pull_params
-            }
-            console.log("call pulls.list:", pulls_list_params)
-            const pulls = (await github.pulls.list(pulls_list_params)).data
-
-            if (0 < pulls.length) {
-              return
-            }
-
-            const pulls_create_params = {
               title: "formatが間違ってたので直してあげたよ！PRをマージしてね！ #${{github.event.pull_request.number}}",
-              body: "鳩の唐揚げおいしい！😋😋😋 #${{github.event.pull_request.number}}",
-              ...pull_params
+              body: "鳩の唐揚げおいしい！😋😋😋 #${{github.event.pull_request.number}}"
             }
             console.log("call pulls.create:", pulls_create_params)
             const create_pull_res = (await github.pulls.create(pulls_create_params)).data
-
-            if ("${{github.event.pull_request.user.login}}" === "dependabot[bot]") {
-              return
-            }
-
+            return create_pull_res.number
+      - name: Assign a user
+        uses: actions/github-script@v4.1
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.format.outcome == 'failure' && steps.get_pull_requests.outputs.result == 0 && github.event.pull_request.user.login != 'dependabot[bot]' }}
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
             const issues_add_assignees_params = {
-              issue_number: create_pull_res.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{steps.create_pull_request.outputs.result}},
               assignees: ["${{github.event.pull_request.user.login}}"],
               ...common_params
             }

--- a/.github/workflows/pr-textlint.yml
+++ b/.github/workflows/pr-textlint.yml
@@ -143,7 +143,7 @@ jobs:
           git add -u
           git commit -m "鳩は唐揚げ！(自動で直してあげたよ！)"
           git push -f https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git "HEAD:refs/heads/fix-text-${HEAD_REF}"
-      - name: Get pull requests
+      - name: Get PullRequests
         uses: actions/github-script@v4.1
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}

--- a/.github/workflows/pr-textlint.yml
+++ b/.github/workflows/pr-textlint.yml
@@ -61,7 +61,7 @@ jobs:
              repo: context.repo.repo
             }
             console.log("call issues.listComments:", issues_listComments_params)
-            const issue_comments = (await github.issues.listComments(issues_listComments_params)).data.filter(
+            const issue_comments = (await github.paginate(github.issues.listComments, issues_listComments_params)).filter(
               issue_comment => issue_comment.user.id==41898282 && issue_comment.body.startsWith('日本語の')
             )
 
@@ -161,7 +161,7 @@ jobs:
               state: "open"
             }
             console.log("call pulls.list:", pulls_list_params)
-            const pulls = (await github.pulls.list(pulls_list_params)).data
+            const pulls = await github.paginate(github.pulls.list, pulls_list_params)
             return pulls.length
       # pushしたブランチでPRを作る
       - name: Create PullRequest
@@ -221,7 +221,7 @@ jobs:
               ...common_params
             }
             console.log("call pulls.list:", pulls_list_params)
-            const pulls = (await github.pulls.list(pulls_list_params)).data
+            const pulls = await github.paginate(github.pulls.list, pulls_list_params)
 
             for (const data of pulls) {
               const pulls_update_params = {

--- a/.github/workflows/pr-textlint.yml
+++ b/.github/workflows/pr-textlint.yml
@@ -143,52 +143,59 @@ jobs:
           git add -u
           git commit -m "鳩は唐揚げ！(自動で直してあげたよ！)"
           git push -f https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git "HEAD:refs/heads/fix-text-${HEAD_REF}"
+      - name: Get pull requests
+        uses: actions/github-script@v4.1
+        env:
+          HEAD_REF: ${{github.event.pull_request.head.ref}}
+        if: ${{ steps.show_diff.outputs.diff != '' }}
+        id: get_pull_requests
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const HEAD_REF = process.env["HEAD_REF"]
+            const pulls_list_params = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: "dev-hato:fix-text-" + HEAD_REF,
+              base: HEAD_REF,
+              state: "open"
+            }
+            console.log("call pulls.list:", pulls_list_params)
+            const pulls = (await github.pulls.list(pulls_list_params)).data
+            return pulls.length
       # pushしたブランチでPRを作る
       - name: Create PullRequest
         uses: actions/github-script@v4.1
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
-        if: ${{ steps.show_diff.outputs.diff != '' }}
+        if: ${{ steps.show_diff.outputs.diff != '' && steps.get_pull_requests.outputs.result == 0 }}
+        id: create_pull_request
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const HEAD_REF = process.env["HEAD_REF"]
-            const common_params = {
+            const pulls_create_params = {
               owner: context.repo.owner,
-              repo: context.repo.repo
-            }
-            const pull_params = {
+              repo: context.repo.repo,
               head: "dev-hato:fix-text-" + HEAD_REF,
               base: HEAD_REF,
-              ...common_params
-            }
-            const pulls_list_params = {
-              state: "open",
-              ...pull_params
-            }
-            console.log("call pulls.list:", pulls_list_params)
-            const pulls = (await github.pulls.list(pulls_list_params)).data
-
-            if (0 < pulls.length) {
-              return
-            }
-
-            const pulls_create_params = {
               title: "日本語が間違ってたので直してあげたよ！PRをマージしてね！ #${{github.event.pull_request.number}}",
-              body: "鳩の唐揚げおいしい！😋😋😋 #${{github.event.pull_request.number}}",
-              ...pull_params
+              body: "鳩の唐揚げおいしい！😋😋😋 #${{github.event.pull_request.number}}"
             }
             console.log("call pulls.create:", pulls_create_params)
             const create_pull_res = (await github.pulls.create(pulls_create_params)).data
-
-            if ("${{github.event.pull_request.user.login}}" === "dependabot[bot]") {
-              return
-            }
-
+            return create_pull_res.number
+      - name: Assign a user
+        uses: actions/github-script@v4.1
+        if: ${{ steps.show_diff.outputs.diff != '' && steps.get_pull_requests.outputs.result == 0 && github.event.pull_request.user.login != 'dependabot[bot]' }}
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
             const issues_add_assignees_params = {
-              issue_number: create_pull_res.number,
-              assignees: ["${{github.event.pull_request.user.login}}"],
-              ...common_params
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{steps.create_pull_request.outputs.result}},
+              assignees: ["${{github.event.pull_request.user.login}}"]
             }
             console.log("call issues.addAssignees:", issues_add_assignees_params)
             await github.issues.addAssignees(issues_add_assignees_params)

--- a/.github/workflows/secretlint.yml
+++ b/.github/workflows/secretlint.yml
@@ -61,7 +61,7 @@ jobs:
              repo: context.repo.repo
             }
             console.log("call issues.listComments:", issues_listComments_params)
-            const issue_comments = (await github.issues.listComments(issues_listComments_params)).data.filter(
+            const issue_comments = (await github.paginate(github.issues.listComments, issues_listComments_params)).filter(
               issue_comment => issue_comment.user.id==41898282 && issue_comment.body.startsWith('secretlintの')
             )
 


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/pull/409 でのレビューに基づいて、早期returnしている箇所を別のstepに分離し、stepのifで実行を制御するようにします。
また、GitHub API ( `list*` ) をページネーションに対応させます。