### PR TITLE
actions/github-scriptアップデート

### DIFF
--- a/.github/workflows/pr-check-yarn.yml
+++ b/.github/workflows/pr-check-yarn.yml
@@ -44,7 +44,7 @@ jobs:
           git commit -m "鳩は唐揚げ！(自動で直してあげたよ！)"
           git push -f https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git "HEAD:refs/heads/yarn-${HEAD_REF}"
       - name: Get PullRequests
-        uses: actions/github-script@v4.1
+        uses: actions/github-script@v5
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.diff.outputs.result != '' }}
@@ -65,7 +65,7 @@ jobs:
             return pulls.length
       # pushしたブランチでPRを作る
       - name: Create PullRequest
-        uses: actions/github-script@v4.1
+        uses: actions/github-script@v5
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.diff.outputs.result != '' && steps.get_pull_requests.outputs.result == 0 }}
@@ -86,7 +86,7 @@ jobs:
             const create_pull_res = (await github.pulls.create(pulls_create_params)).data
             return create_pull_res.number
       - name: Assign a user
-        uses: actions/github-script@v4.1
+        uses: actions/github-script@v5
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.diff.outputs.result != '' && steps.get_pull_requests.outputs.result == 0 && github.event.pull_request.user.login != 'dependabot[bot]' }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -101,7 +101,7 @@ jobs:
             await github.issues.addAssignees(issues_add_assignees_params)
       # 既にpackage.json, yarn.lock修正のPRがある状態で、手動でpackage.json, yarn.lockを修正した場合、修正のPRを閉じる
       - name: Close PullRequest
-        uses: actions/github-script@v4.1
+        uses: actions/github-script@v5
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.diff.outputs.result == '' }}

--- a/.github/workflows/pr-check-yarn.yml
+++ b/.github/workflows/pr-check-yarn.yml
@@ -61,7 +61,7 @@ jobs:
               state: "open"
             }
             console.log("call pulls.list:", pulls_list_params)
-            const pulls = await github.paginate(github.pulls.list, pulls_list_params)
+            const pulls = await github.paginate(github.rest.pulls.list, pulls_list_params)
             return pulls.length
       # pushしたブランチでPRを作る
       - name: Create PullRequest
@@ -83,7 +83,7 @@ jobs:
               body: "鳩の唐揚げおいしい！😋😋😋 #${{github.event.pull_request.number}}"
             }
             console.log("call pulls.create:", pulls_create_params)
-            const create_pull_res = (await github.pulls.create(pulls_create_params)).data
+            const create_pull_res = (await github.rest.pulls.create(pulls_create_params)).data
             return create_pull_res.number
       - name: Assign a user
         uses: actions/github-script@v5
@@ -98,7 +98,7 @@ jobs:
               assignees: ["${{github.event.pull_request.user.login}}"]
             }
             console.log("call issues.addAssignees:", issues_add_assignees_params)
-            await github.issues.addAssignees(issues_add_assignees_params)
+            await github.rest.issues.addAssignees(issues_add_assignees_params)
       # 既にpackage.json, yarn.lock修正のPRがある状態で、手動でpackage.json, yarn.lockを修正した場合、修正のPRを閉じる
       - name: Close PullRequest
         uses: actions/github-script@v5
@@ -121,7 +121,7 @@ jobs:
               ...common_params
             }
             console.log("call pulls.list:", pulls_list_params)
-            const pulls = await github.paginate(github.pulls.list, pulls_list_params)
+            const pulls = await github.paginate(github.rest.pulls.list, pulls_list_params)
 
             for (const pull of pulls) {
               const pulls_update_params = {
@@ -130,13 +130,13 @@ jobs:
                 ...common_params
               }
               console.log("call pulls.update:", pulls_update_params)
-              await github.pulls.update(pulls_update_params)
+              await github.rest.pulls.update(pulls_update_params)
               const git_deleteRef_params = {
                 ref: "heads/" + head_name,
                 ...common_params
               }
               console.log("call git.deleteRef:", git_deleteRef_params)
-              await github.git.deleteRef(git_deleteRef_params)
+              await github.rest.git.deleteRef(git_deleteRef_params)
             }
       - name: Exit
         if: ${{ steps.diff.outputs.result != '' }}

--- a/.github/workflows/pr-merge-develop-hato-bot.yml
+++ b/.github/workflows/pr-merge-develop-hato-bot.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Get PullRequests
-        uses: actions/github-script@v4.1
+        uses: actions/github-script@v5
         id: get_pull_requests
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -35,7 +35,7 @@ jobs:
             const pulls = await github.paginate(github.pulls.list, pulls_list_params)
             return pulls.length
       - name: Create PullRequest
-        uses: actions/github-script@v4.1
+        uses: actions/github-script@v5
         if: ${{ steps.get_pull_requests.outputs.result == 0 }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/pr-merge-develop-hato-bot.yml
+++ b/.github/workflows/pr-merge-develop-hato-bot.yml
@@ -32,7 +32,7 @@ jobs:
               state: "open"
             }
             console.log("call pulls.list:", pulls_list_params)
-            const pulls = await github.paginate(github.pulls.list, pulls_list_params)
+            const pulls = await github.paginate(github.rest.pulls.list, pulls_list_params)
             return pulls.length
       - name: Create PullRequest
         uses: actions/github-script@v5
@@ -52,7 +52,7 @@ jobs:
               ...common_params
             }
             console.log("call pulls.create:", pulls_create_params)
-            const create_pull_res = (await github.pulls.create(pulls_create_params)).data
+            const create_pull_res = (await github.rest.pulls.create(pulls_create_params)).data
             const release_users = ["nakkaa"]
             const pulls_request_reviews_params = {
               pull_number: create_pull_res.number,
@@ -60,11 +60,11 @@ jobs:
               ...common_params
             }
             console.log("call pulls.requestReviewers:", pulls_request_reviews_params)
-            await github.pulls.requestReviewers(pulls_request_reviews_params)
+            await github.rest.pulls.requestReviewers(pulls_request_reviews_params)
             const issues_add_assignees_params = {
               issue_number: create_pull_res.number,
               assignees: release_users,
               ...common_params
             }
             console.log("call issues.addAssignees:", issues_add_assignees_params)
-            await github.issues.addAssignees(issues_add_assignees_params)
+            await github.rest.issues.addAssignees(issues_add_assignees_params)

--- a/.github/workflows/pr-release-hato-bot.yml
+++ b/.github/workflows/pr-release-hato-bot.yml
@@ -40,7 +40,7 @@ jobs:
               state: "open"
             }
             console.log("call pulls.list:", pulls_list_params)
-            const pulls = await github.paginate(github.pulls.list, pulls_list_params)
+            const pulls = await github.paginate(github.rest.pulls.list, pulls_list_params)
             return pulls.length
       - name: Create PullRequest
         uses: actions/github-script@v5
@@ -61,7 +61,7 @@ jobs:
               ...common_params
             }
             console.log("call pulls.create:", pulls_create_params)
-            const create_pull_res = (await github.pulls.create(pulls_create_params)).data
+            const create_pull_res = (await github.rest.pulls.create(pulls_create_params)).data
             const release_users = ["nakkaa"]
             const pulls_request_reviews_params = {
               pull_number: create_pull_res.number,
@@ -69,11 +69,11 @@ jobs:
               ...common_params
             }
             console.log("call pulls.requestReviewers:", pulls_request_reviews_params)
-            await github.pulls.requestReviewers(pulls_request_reviews_params)
+            await github.rest.pulls.requestReviewers(pulls_request_reviews_params)
             const issues_add_assignees_params = {
               issue_number: create_pull_res.number,
               assignees: release_users,
               ...common_params
             }
             console.log("call issues.addAssignees:", issues_add_assignees_params)
-            await github.issues.addAssignees(issues_add_assignees_params)
+            await github.rest.issues.addAssignees(issues_add_assignees_params)

--- a/.github/workflows/pr-release-hato-bot.yml
+++ b/.github/workflows/pr-release-hato-bot.yml
@@ -26,7 +26,7 @@ jobs:
           result="${result//$'\r'/'%0D'}"
           echo "::set-output name=result::${result}"
       - name: Get PullRequests
-        uses: actions/github-script@v4.1
+        uses: actions/github-script@v5
         if: ${{ steps.get_diff.outputs.result != '' }}
         id: get_pull_requests
         with:
@@ -43,7 +43,7 @@ jobs:
             const pulls = await github.paginate(github.pulls.list, pulls_list_params)
             return pulls.length
       - name: Create PullRequest
-        uses: actions/github-script@v4.1
+        uses: actions/github-script@v5
         if: ${{ steps.get_diff.outputs.result != '' && steps.get_pull_requests.outputs.result == 0 }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -131,7 +131,7 @@ jobs:
               ...common_params
             }
             console.log("call issues.addAssignees:", issues_add_assignees_params)
-            await github.issues.addAssignees(issues_add_assignees_params)
+            await github.rest.issues.addAssignees(issues_add_assignees_params)
       # 既にformat修正のPRがある状態で、手動でformatを修正した場合、format修正のPRを閉じる
       - name: Close PullRequest
         uses: actions/github-script@v5
@@ -154,7 +154,7 @@ jobs:
               ...common_params
             }
             console.log("call pulls.list:", pulls_list_params)
-            const pulls = await github.paginate(github.pulls.list, pulls_list_params)
+            const pulls = await github.paginate(github.rest.pulls.list, pulls_list_params)
 
             for(const data of pulls) {
               const pulls_update_params = {
@@ -163,13 +163,13 @@ jobs:
                 ...common_params
               }
               console.log("call pulls.update:", pulls_update_params)
-              await github.pulls.update(pulls_update_params)
+              await github.rest.pulls.update(pulls_update_params)
               const git_deleteRef_params = {
                 ref: "heads/" + head_name,
                 ...common_params
               }
               console.log("call git.deleteRef:", git_deleteRef_params)
-              await github.git.deleteRef(git_deleteRef_params)
+              await github.rest.git.deleteRef(git_deleteRef_params)
             }
       - name: Exit
         if: ${{ steps.format.outcome == 'failure' }}

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -76,7 +76,7 @@ jobs:
           git commit -m "鳩は唐揚げ！(自動で直してあげたよ！)"
           git push -f https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git "HEAD:refs/heads/fix-format-${HEAD_REF}"
       - name: Get PullRequests
-        uses: actions/github-script@v4.1
+        uses: actions/github-script@v5
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.format.outcome == 'failure' }}
@@ -97,7 +97,7 @@ jobs:
             return pulls.length
       # pushしたブランチでPRを作る
       - name: Create PullRequest
-        uses: actions/github-script@v4.1
+        uses: actions/github-script@v5
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.format.outcome == 'failure' && steps.get_pull_requests.outputs.result == 0 }}
@@ -118,7 +118,7 @@ jobs:
             const create_pull_res = (await github.pulls.create(pulls_create_params)).data
             return create_pull_res.number
       - name: Assign a user
-        uses: actions/github-script@v4.1
+        uses: actions/github-script@v5
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.format.outcome == 'failure' && steps.get_pull_requests.outputs.result == 0 && github.event.pull_request.user.login != 'dependabot[bot]' }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -134,7 +134,7 @@ jobs:
             await github.issues.addAssignees(issues_add_assignees_params)
       # 既にformat修正のPRがある状態で、手動でformatを修正した場合、format修正のPRを閉じる
       - name: Close PullRequest
-        uses: actions/github-script@v4.1
+        uses: actions/github-script@v5
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.format.outcome != 'failure' }}

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -93,7 +93,7 @@ jobs:
               state: "open"
             }
             console.log("call pulls.list:", pulls_list_params)
-            const pulls = await github.paginate(github.pulls.list, pulls_list_params)
+            const pulls = await github.paginate(github.rest.pulls.list, pulls_list_params)
             return pulls.length
       # pushしたブランチでPRを作る
       - name: Create PullRequest
@@ -115,7 +115,7 @@ jobs:
               body: "鳩の唐揚げおいしい！😋😋😋 #${{github.event.pull_request.number}}"
             }
             console.log("call pulls.create:", pulls_create_params)
-            const create_pull_res = (await github.pulls.create(pulls_create_params)).data
+            const create_pull_res = (await github.rest.pulls.create(pulls_create_params)).data
             return create_pull_res.number
       - name: Assign a user
         uses: actions/github-script@v5

--- a/.github/workflows/pr-textlint.yml
+++ b/.github/workflows/pr-textlint.yml
@@ -51,7 +51,7 @@ jobs:
       # lint結果をコメントに残す
       - name: Lint Comment
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.lint.outputs.result != '' }}
-        uses: actions/github-script@v4.1
+        uses: actions/github-script@v5
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -144,7 +144,7 @@ jobs:
           git commit -m "鳩は唐揚げ！(自動で直してあげたよ！)"
           git push -f https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git "HEAD:refs/heads/fix-text-${HEAD_REF}"
       - name: Get PullRequests
-        uses: actions/github-script@v4.1
+        uses: actions/github-script@v5
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ steps.show_diff.outputs.diff != '' }}
@@ -165,7 +165,7 @@ jobs:
             return pulls.length
       # pushしたブランチでPRを作る
       - name: Create PullRequest
-        uses: actions/github-script@v4.1
+        uses: actions/github-script@v5
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ steps.show_diff.outputs.diff != '' && steps.get_pull_requests.outputs.result == 0 }}
@@ -186,7 +186,7 @@ jobs:
             const create_pull_res = (await github.pulls.create(pulls_create_params)).data
             return create_pull_res.number
       - name: Assign a user
-        uses: actions/github-script@v4.1
+        uses: actions/github-script@v5
         if: ${{ steps.show_diff.outputs.diff != '' && steps.get_pull_requests.outputs.result == 0 && github.event.pull_request.user.login != 'dependabot[bot]' }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -201,7 +201,7 @@ jobs:
             await github.issues.addAssignees(issues_add_assignees_params)
       # 既にformat修正のPRがある状態で、手動でformatを修正した場合、format修正のPRを閉じる
       - name: Close PullRequest
-        uses: actions/github-script@v4.1
+        uses: actions/github-script@v5
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ steps.show_diff.outputs.diff == '' }}

--- a/.github/workflows/pr-textlint.yml
+++ b/.github/workflows/pr-textlint.yml
@@ -61,7 +61,7 @@ jobs:
              repo: context.repo.repo
             }
             console.log("call issues.listComments:", issues_listComments_params)
-            const issue_comments = (await github.paginate(github.issues.listComments, issues_listComments_params)).filter(
+            const issue_comments = (await github.paginate(github.rest.issues.listComments, issues_listComments_params)).filter(
               issue_comment => issue_comment.user.id==41898282 && issue_comment.body.startsWith('日本語の')
             )
 
@@ -72,7 +72,7 @@ jobs:
                 repo: context.repo.repo
               }
               console.log("call issues.deleteComment:", issues_deleteComment_params)
-              await github.issues.deleteComment(issues_deleteComment_params)
+              await github.rest.issues.deleteComment(issues_deleteComment_params)
             }
 
             const result = `${{steps.lint.outputs.result}}`
@@ -83,7 +83,7 @@ jobs:
               body: "日本語のLint結果だよ！🕊🕊🕊\n```\n"+result+"\n```"
             }
             console.log("call issues.createComment:", issues_createComment_params)
-            await github.issues.createComment(issues_createComment_params)
+            await github.rest.issues.createComment(issues_createComment_params)
       - name: Exit
         if: ${{ github.event.pull_request.head.repo.full_name != github.repository && steps.lint.outcome == 'failure' }}
         run: exit 1
@@ -161,7 +161,7 @@ jobs:
               state: "open"
             }
             console.log("call pulls.list:", pulls_list_params)
-            const pulls = await github.paginate(github.pulls.list, pulls_list_params)
+            const pulls = await github.paginate(github.rest.pulls.list, pulls_list_params)
             return pulls.length
       # pushしたブランチでPRを作る
       - name: Create PullRequest
@@ -183,7 +183,7 @@ jobs:
               body: "鳩の唐揚げおいしい！😋😋😋 #${{github.event.pull_request.number}}"
             }
             console.log("call pulls.create:", pulls_create_params)
-            const create_pull_res = (await github.pulls.create(pulls_create_params)).data
+            const create_pull_res = (await github.rest.pulls.create(pulls_create_params)).data
             return create_pull_res.number
       - name: Assign a user
         uses: actions/github-script@v5
@@ -198,7 +198,7 @@ jobs:
               assignees: ["${{github.event.pull_request.user.login}}"]
             }
             console.log("call issues.addAssignees:", issues_add_assignees_params)
-            await github.issues.addAssignees(issues_add_assignees_params)
+            await github.rest.issues.addAssignees(issues_add_assignees_params)
       # 既にformat修正のPRがある状態で、手動でformatを修正した場合、format修正のPRを閉じる
       - name: Close PullRequest
         uses: actions/github-script@v5
@@ -221,7 +221,7 @@ jobs:
               ...common_params
             }
             console.log("call pulls.list:", pulls_list_params)
-            const pulls = await github.paginate(github.pulls.list, pulls_list_params)
+            const pulls = await github.paginate(github.rest.pulls.list, pulls_list_params)
 
             for (const data of pulls) {
               const pulls_update_params = {

--- a/.github/workflows/pr-textlint.yml
+++ b/.github/workflows/pr-textlint.yml
@@ -230,13 +230,13 @@ jobs:
                 ...common_params
               }
               console.log("call pulls.update:", pulls_update_params)
-              await github.pulls.update(pulls_update_params)
+              await github.rest.pulls.update(pulls_update_params)
               const git_deleteRef_params = {
                 ref: "heads/" + head_name,
                 ...common_params
               }
               console.log("call git.deleteRef:", git_deleteRef_params)
-              await github.git.deleteRef(git_deleteRef_params)
+              await github.rest.git.deleteRef(git_deleteRef_params)
             }
       - name: Exit
         if: ${{ steps.show_diff.outputs.diff != '' }}

--- a/.github/workflows/secretlint.yml
+++ b/.github/workflows/secretlint.yml
@@ -51,7 +51,7 @@ jobs:
       # lint結果をコメントに残す
       - name: Lint Comment
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.lint.outputs.result != '' }}
-        uses: actions/github-script@v4.1
+        uses: actions/github-script@v5
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/secretlint.yml
+++ b/.github/workflows/secretlint.yml
@@ -61,7 +61,7 @@ jobs:
              repo: context.repo.repo
             }
             console.log("call issues.listComments:", issues_listComments_params)
-            const issue_comments = (await github.paginate(github.issues.listComments, issues_listComments_params)).filter(
+            const issue_comments = (await github.paginate(github.rest.issues.listComments, issues_listComments_params)).filter(
               issue_comment => issue_comment.user.id==41898282 && issue_comment.body.startsWith('secretlintの')
             )
 
@@ -72,7 +72,7 @@ jobs:
                 repo: context.repo.repo
               }
               console.log("call issues.deleteComment:", issues_deleteComment_params)
-              await github.issues.deleteComment(issues_deleteComment_params)
+              await github.rest.issues.deleteComment(issues_deleteComment_params)
             }
 
             const result = `${{steps.lint.outputs.result}}`
@@ -83,7 +83,7 @@ jobs:
               body: "secretlintのLint結果だよ！🕊🕊🕊\n```\n"+result+"\n```"
             }
             console.log("call issues.createComment:", issues_createComment_params)
-            await github.issues.createComment(issues_createComment_params)
+            await github.rest.issues.createComment(issues_createComment_params)
       - name: Exit
         if: ${{ github.event.pull_request.head.repo.full_name != github.repository && steps.lint.outcome == 'failure' }}
         run: exit 1


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/pull/704 をベースにactions/github-scriptをアップデートします。
なお、 `actions/github-script v5` ではREST API呼び出し時に `github.rest.~` を使う必要があるため修正しています。
参考: https://github.com/actions/github-script#breaking-changes-in-v5