### PR TITLE
CI update-pre-commit-config 修正

### DIFF
--- a/.github/workflows/pr-update-pre-commit-config-hato-bot.yml
+++ b/.github/workflows/pr-update-pre-commit-config-hato-bot.yml
@@ -8,6 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Install packages
         run: yarn add js-yaml
       - name: Update .pre-commit-config.yaml


### PR DESCRIPTION
CI `update-pre-commit-config` でcheckout時の設定を忘れていたので、PRを作れるよう修正します。