### PR TITLE
CIで使用するNode.jsを16系にする

### DIFF
--- a/.github/workflows/pr-check-yarn.yml
+++ b/.github/workflows/pr-check-yarn.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
       fail-fast: false
 
     steps:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -180,7 +180,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.9]
-        node-version: [14.x]
+        node-version: [16.x]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
https://nodejs.org/ja/about/releases/

16系がアクティブ LTSになっているので、CIで使用するNode.jsを16系にします。