### PR TITLE
sudden-deathへの反映CI内のパス修正

### DIFF
--- a/.github/workflows/pr-copy-ci-hato-bot.yml
+++ b/.github/workflows/pr-copy-ci-hato-bot.yml
@@ -27,7 +27,7 @@ jobs:
           find hato-bot/${worklows_path} -type f -not -name "*hato-bot.yml" -exec cp {} sudden-death/${worklows_path}/ \;
           for f in .markdown-lint.yml .python-lint .python-lint
           do
-            cp hato-bot/linters/${f} sudden-death/linters/
+            cp hato-bot/.github/linters/${f} sudden-death/.github/linters/
           done
           for f in .gitleaks.toml .pre-commit-config.yaml package.json yarn.lock
           do


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/runs/4240324680?check_suite_focus=true#step:4:15

```
cp: cannot stat 'hato-bot/linters/.markdown-lint.yml': No such file or directory
```

linterの設定ファイルのパスを間違えていたので修正します。