### PR TITLE
CI pr-test-hato-bot/pr-test のキャッシュ強制クリア

### DIFF
--- a/.github/workflows/pr-test-hato-bot.yml
+++ b/.github/workflows/pr-test-hato-bot.yml
@@ -27,11 +27,11 @@ jobs:
       - name: pipenv cache
         uses: actions/cache@v2.1.7
         with:
-          key: ${{ hashFiles('./.github/workflows/pr-test-hato-bot.yml') }}-${{ runner.os }}-${{ matrix.python-version }}-Dockerfile-${{ hashFiles('./Dockerfile') }}-pipenv-${{ hashFiles('./Pipfile') }}
+          key: ${{ hashFiles('./.github/workflows/pr-test-hato-bot.yml') }}-${{ runner.os }}-${{ matrix.python-version }}-Dockerfile-${{ hashFiles('./Dockerfile') }}-pipenv-v2-${{ hashFiles('./Pipfile') }}
           path: ${{ env.WORKON_HOME }}
           restore-keys: |
-            ${{ hashFiles('./.github/workflows/pr-test-hato-bot.yml') }}-${{ runner.os }}-${{ matrix.python-version }}-Dockerfile-${{ hashFiles('./Dockerfile') }}-pipenv-${{ hashFiles('./Pipfile') }}
-            ${{ hashFiles('./.github/workflows/pr-test-hato-bot.yml') }}-${{ runner.os }}-${{ matrix.python-version }}-Dockerfile-${{ hashFiles('./Dockerfile') }}-pipenv-
+            ${{ hashFiles('./.github/workflows/pr-test-hato-bot.yml') }}-${{ runner.os }}-${{ matrix.python-version }}-Dockerfile-${{ hashFiles('./Dockerfile') }}-pipenv-v2-${{ hashFiles('./Pipfile') }}
+            ${{ hashFiles('./.github/workflows/pr-test-hato-bot.yml') }}-${{ runner.os }}-${{ matrix.python-version }}-Dockerfile-${{ hashFiles('./Dockerfile') }}-pipenv-v2-
       - name: Install pipenv
         run: |
           file_name=Dockerfile


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/runs/4366209175?check_suite_focus=true

```
An error occurred while installing git+https://github.com/dev-hato/sudden-death@001bbf8178f67d318e5a32998136a92b51baec82#egg=sudden-death! Will try again.
...
[pipenv.exceptions.InstallError]: /bin/sh: 1: /tmp/.venv/hato-bot-e4tWitUV/bin/pip: not found
ERROR: Couldn't install package: sudden-death
 Package installation failed...
Error: Process completed with exit code 1.
```

https://github.com/dev-hato/hato-bot/commit/6e4e98c156225684b9b95831de8382ecdd52b60b のCI `pr-test-hato-bot/pr-test` が落ちているので、キャッシュを強制的にクリアしてみます。