### PR TITLE
CI pr-check-yarnでNode.jsのキャッシュを効かせる

### DIFF
--- a/.github/workflows/pr-check-yarn.yml
+++ b/.github/workflows/pr-check-yarn.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/setup-node@v2.5.0
         with:
           node-version: ${{ matrix.node-version }}
+          cache: yarn
       - name: Install dependencies
         run: |
           yarn install -D

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/zricethezav/gitleaks
-    rev: v8.0.7
+    rev: v8.1.0
     hooks:
       - id: gitleaks


### PR DESCRIPTION
CI `pr-check-yarn` でもNode.jsのキャッシュを効かせます。