### PR TITLE
CI pr-copy-ci-hato-bot修正

### DIFF
--- a/.github/workflows/pr-copy-ci-hato-bot.yml
+++ b/.github/workflows/pr-copy-ci-hato-bot.yml
@@ -64,4 +64,5 @@ jobs:
           GIT_SSH_COMMAND+=" -i deploy_key.pem"
           GIT_SSH_COMMAND+=" -o StrictHostKeyChecking=no"
           GIT_SSH_COMMAND+=" -F /dev/null"
+          export GIT_SSH_COMMAND
           git push -f "${REPO_URL}" "${GITHUB_HEAD}"


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/runs/4990418358?check_suite_focus=true

```
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
Error: Process completed with exit code 128.
```

`GIT_SSH_COMMAND` をexportするよう修正します。