### PR TITLE
コードやURLを含むコマンドも平文として解釈する

### DIFF
--- a/run.py
+++ b/run.py
@@ -11,7 +11,6 @@ from concurrent.futures import ThreadPoolExecutor
 from slackeventsapi import SlackEventAdapter
 from flask import Flask, request, escape
 import slackbot_settings as conf
-from plugins import hato
 from plugins import analyze
 from library.clientclass import SlackClient, ApiClient
 from library.database import Database

--- a/run.py
+++ b/run.py
@@ -38,11 +38,8 @@ def __init__():
 def analyze_slack_message(messages: List[dict]) -> Callable[[SlackClient], None]:
     """Slackコマンド解析"""
 
-    if len(messages) > 0 and messages[0]['type'] == 'text':
-        message = messages[0]['text'].strip()
-        return analyze.analyze_message(message)
-
-    return hato.default_action
+    message = ''.join([m['text'] for m in messages if 'text' in m]).strip()
+    return analyze.analyze_message(message)
 
 
 @slack_events_adapter.on("app_mention")

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,0 +1,33 @@
+"""
+run.pyのテスト
+"""
+
+import unittest
+
+from run import analyze_slack_message
+from plugins import hato
+from tests.plugins import TestClient
+
+
+class TestAnalyzeSlackMessage(unittest.TestCase):
+    """
+    Slackコマンドを正しく解析できるかテストする
+    """
+
+    def test_telephone_link(self):
+        """電話番号のリンクを含むコマンドを正しく解析できる"""
+        client1 = TestClient()
+        messages = [{'type': 'text', 'text': '>< '}, {'type': 'link', 'url': 'tel:09012345678', 'text': '09012345678'}]
+        analyze_slack_message(messages)(client1)
+        client2 = TestClient()
+        hato.totuzensi('09012345678')(client2)
+        self.assertEqual(client1.get_post_message(), client2.get_post_message())
+
+    def test_code(self):
+        """コードを含むコマンドを正しく解析できる"""
+        client1 = TestClient()
+        messages = [{'type': 'text', 'text': '>< '}, {'type': 'text', 'text': '09012345678', 'style': {'code': True}}]
+        analyze_slack_message(messages)(client1)
+        client2 = TestClient()
+        hato.totuzensi('09012345678')(client2)
+        self.assertEqual(client1.get_post_message(), client2.get_post_message())

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -17,7 +17,10 @@ class TestAnalyzeSlackMessage(unittest.TestCase):
     def test_telephone_link(self):
         """電話番号のリンクを含むコマンドを正しく解析できる"""
         client1 = TestClient()
-        messages = [{'type': 'text', 'text': '>< '}, {'type': 'link', 'url': 'tel:09012345678', 'text': '09012345678'}]
+        messages = [
+            {'type': 'text', 'text': '>< '},
+            {'type': 'link', 'url': 'tel:09012345678', 'text': '09012345678'}
+        ]
         analyze_slack_message(messages)(client1)
         client2 = TestClient()
         hato.totuzensi('09012345678')(client2)
@@ -26,7 +29,10 @@ class TestAnalyzeSlackMessage(unittest.TestCase):
     def test_code(self):
         """コードを含むコマンドを正しく解析できる"""
         client1 = TestClient()
-        messages = [{'type': 'text', 'text': '>< '}, {'type': 'text', 'text': '09012345678', 'style': {'code': True}}]
+        messages = [
+            {'type': 'text', 'text': '>< '},
+            {'type': 'text', 'text': '09012345678', 'style': {'code': True}}
+        ]
         analyze_slack_message(messages)(client1)
         client2 = TestClient()
         hato.totuzensi('09012345678')(client2)


### PR DESCRIPTION
以下のようなコードやURLを含むコマンドも平文として解釈してコマンド実行するようにします。

```
@hato >< `09012345678`
@hato >< [09012345678](tel:09012345678)
```