### PR TITLE
GitHub PackagesへのデプロイCI修正

### DIFF
--- a/.github/workflows/pr-docker-hato-bot.yml
+++ b/.github/workflows/pr-docker-hato-bot.yml
@@ -39,9 +39,9 @@ jobs:
           HEAD_REF: ${{github.head_ref}}
         if: ${{ github.event_name == 'pull_request' }}
       - run: |
-          echo 'TAG_NAME=v${{ github.event.release.tag_name }}' >> "$GITHUB_ENV"
+          echo 'TAG_NAME=${{ github.event.release.tag_name }}' >> "$GITHUB_ENV"
           echo 'TAG_NAME=latest' >> "$GITHUB_ENV"
-        if: ${{ github.event_name == 'relase' }}
+        if: ${{ github.event_name == 'release' }}
       - name: Build docker image
         run: docker-compose build --build-arg BUILDKIT_INLINE_CACHE=1
       - name: Start docker


### PR DESCRIPTION
GitHub PackagesへのデプロイCIを以下の通り修正します。
* リリース時に付与するタグ名の `v` が重複していたので削除
* リリース時にトリガーするステップの実行条件のtypo修正

失敗したCI: https://github.com/dev-hato/hato-bot/runs/5151741810?check_suite_focus=true