### PR TITLE
CI update-python はsudden-deathに同期しない

### DIFF
--- a/.github/workflows/update_python-hato-bot.yml
+++ b/.github/workflows/update_python-hato-bot.yml
@@ -1,5 +1,5 @@
 ---
-name: update-python
+name: update-python-hato-bot
 
 on:
   pull_request:


### PR DESCRIPTION
https://github.com/dev-hato/sudden-death にDockerfileはないので、CI `update-python` を https://github.com/dev-hato/sudden-death  に同期しないようにします。