### PR TITLE
postgresのdependabotの設定削除

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,11 +11,6 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 1
-  - package-ecosystem: docker
-    directory: "/setup/pgsql"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 1
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/pull/832 でpostgresのDockerfileを削除したので、dependabotの該当設定を削除します。