### PR TITLE
非推奨のtextlintルール削除

### DIFF
--- a/.github/linters/.textlintrc
+++ b/.github/linters/.textlintrc
@@ -36,7 +36,6 @@
       "1.1.3.箇条書き": false,
       "4.3.1.丸かっこ（）": false,
       "4.3.2.大かっこ［］": false
-    },
-    "spellcheck-tech-word": true
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "textlint-rule-prefer-tari-tari": "^1.0.3",
     "textlint-rule-preset-ja-spacing": "^2.2.0",
     "textlint-rule-preset-ja-technical-writing": "^7.0.0",
-    "textlint-rule-preset-jtf-style": "^2.3.12",
-    "textlint-rule-spellcheck-tech-word": "^5.0.0"
+    "textlint-rule-preset-jtf-style": "^2.3.12"
   },
   "resolutions": {
     "ansi-regex": "^5.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2087,14 +2087,6 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz#3694b5804567a458d3c8045842a6358632f62654"
   integrity sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==
 
-spellcheck-technical-word@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/spellcheck-technical-word/-/spellcheck-technical-word-2.0.0.tgz#cb0376b8bbda6239b6be009878cf81cf17080503"
-  integrity sha1-ywN2uLvaYjm2vgCYeM+BzxcIBQM=
-  dependencies:
-    structured-source "^3.0.2"
-    technical-word-rules "^1.4.2"
-
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
@@ -2197,11 +2189,6 @@ table@^6.7.3:
     string-width "^4.2.3"
     strip-ansi "^6.0.1"
 
-technical-word-rules@^1.4.2:
-  version "1.9.5"
-  resolved "https://registry.yarnpkg.com/technical-word-rules/-/technical-word-rules-1.9.5.tgz#49f0a9e78c6b2ef02a1a404790ddd8f5310aafbc"
-  integrity sha512-2sqzeb3aE23GtIO9fL9sDbqdt4vnoks7nWZRUgqEvYkjEmmQjrnVfl3WTURBZFrpgAXBNk0AMhWCj+17mzYXhw==
-
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -2233,7 +2220,7 @@ textlint-rule-helper@2.0.1:
   dependencies:
     unist-util-visit "^1.1.0"
 
-textlint-rule-helper@^1.1.2, textlint-rule-helper@^1.1.5:
+textlint-rule-helper@^1.1.5:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/textlint-rule-helper/-/textlint-rule-helper-1.2.0.tgz#be68d47a5146b16dd116278c9aeb7bd35631ccda"
   integrity sha1-vmjUelFGsW3RFieMmut701YxzNo=
@@ -2617,14 +2604,6 @@ textlint-rule-sentence-length@^3.0.0:
     sentence-splitter "^3.2.1"
     textlint-rule-helper "^2.1.1"
     textlint-util-to-string "^3.1.1"
-
-textlint-rule-spellcheck-tech-word@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/textlint-rule-spellcheck-tech-word/-/textlint-rule-spellcheck-tech-word-5.0.0.tgz#279be31fd4b395e1f87b4a1ef6392f1504894c42"
-  integrity sha1-J5vjH9SzleH4e0oe9jkvFQSJTEI=
-  dependencies:
-    spellcheck-technical-word "^2.0.0"
-    textlint-rule-helper "^1.1.2"
 
 textlint-util-to-string@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
https://github.com/azu/textlint-rule-spellcheck-tech-word

>Deprecated: [Proofdict](https://github.com/proofdict/proofdict)を使っているためメンテナンスしていません。

とのことなので `textlint-rule-spellcheck-tech-word` を削除します。