### PR TITLE
forkしたリポジトリでもうまく動作するようにする・リポジトリ名を変数から取得するようにする

### DIFF
--- a/.github/workflows/pr-copy-ci-hato-bot.yml
+++ b/.github/workflows/pr-copy-ci-hato-bot.yml
@@ -16,10 +16,19 @@ jobs:
         with:
           fetch-depth: 0
           path: hato-bot
+      - name: Set org name
+        uses: actions/github-script@v6
+        if: env.REPO_NAME == github.repository
+        id: set_org_name
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          result-encoding: string
+          script:
+            return process.env.GITHUB_REPOSITORY.split('/')[0]
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          repository: dev-hato/sudden-death
+          repository: ${{steps.set_org_name.outputs.result}}/sudden-death
           path: sudden-death
       - name: Copy CI
         run: |
@@ -54,7 +63,7 @@ jobs:
           git commit -m "鳩は唐揚げ！(hato-botのCIを反映するよ！)"
           echo "${{secrets.SUDDEN_DEATH_CI_PRIVATE_KEY}}" > deploy_key.pem
           chmod 600 deploy_key.pem
-          REPO_URL="git@github.com:dev-hato/sudden-death.git"
+          REPO_URL="git@github.com:${{steps.set_org_name.outputs.result}}/sudden-death.git"
           GITHUB_HEAD="HEAD:refs/heads/pr-copy-ci"
           GIT_SSH_COMMAND="ssh"
           GIT_SSH_COMMAND+=" -i deploy_key.pem"

--- a/.github/workflows/pr-copy-ci-hato-bot.yml
+++ b/.github/workflows/pr-copy-ci-hato-bot.yml
@@ -18,7 +18,6 @@ jobs:
           path: hato-bot
       - name: Set org name
         uses: actions/github-script@v6
-        if: env.REPO_NAME == github.repository
         id: set_org_name
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/pr-docker-hato-bot.yml
+++ b/.github/workflows/pr-docker-hato-bot.yml
@@ -18,6 +18,7 @@ jobs:
       COMPOSE_DOCKER_CLI_BUILD: 1
     permissions:
       packages: write
+    if: github.repository == github.event.pull_request.head.repo.full_name
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/pr-docker-hato-bot.yml
+++ b/.github/workflows/pr-docker-hato-bot.yml
@@ -40,11 +40,12 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
       - run: echo 'TAG_NAME=${{ github.event.release.tag_name }}' >> "$GITHUB_ENV"
         if: ${{ github.event_name == 'release' }}
+      - run: echo "REPOSITORY=${{github.repository}}" >> "${GITHUB_ENV}"
       - name: Build docker image
         run: docker-compose build --build-arg BUILDKIT_INLINE_CACHE=1
       - run: docker-compose push
       - run: |
-          image_name="ghcr.io/dev-hato/hato-bot/hato-bot"
+          image_name="ghcr.io/${{env.REPOSITORY}}/hato-bot"
           latest_tag="${image_name}:latest"
           docker tag "${image_name}:${TAG_NAME}" "${latest_tag}"
           docker push "${latest_tag}"

--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -92,6 +92,15 @@ jobs:
           REPO_URL+="${{github.repository}}.git"
           GITHUB_HEAD="HEAD:refs/heads/fix-format-${HEAD_REF}"
           git push -f "${REPO_URL}" "${GITHUB_HEAD}"
+      - name: Set org name
+        uses: actions/github-script@v6
+        if: env.REPO_NAME == github.repository
+        id: set_org_name
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          result-encoding: string
+          script:
+            return process.env.GITHUB_REPOSITORY.split('/')[0]
       - name: Get PullRequests
         uses: actions/github-script@v6
         env:
@@ -107,7 +116,7 @@ jobs:
             const pulls_list_params = {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              head: "dev-hato:fix-format-" + HEAD_REF,
+              head: "${{steps.set_org_name.outputs.result}}:fix-format-" + HEAD_REF,
               base: HEAD_REF,
               state: "open"
             }
@@ -135,7 +144,7 @@ jobs:
             const pulls_create_params = {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              head: "dev-hato:fix-format-" + HEAD_REF,
+              head: "${{steps.set_org_name.outputs.result}}:fix-format-" + HEAD_REF,
               base: HEAD_REF,
               title,
               body: "鳩の唐揚げおいしい！😋😋😋 " + number
@@ -182,7 +191,7 @@ jobs:
               repo: context.repo.repo
             }
             const pulls_list_params = {
-              head: "dev-hato:" + head_name,
+              head: "${{steps.set_org_name.outputs.result}}:" + head_name,
               base: HEAD_REF,
               state: "open",
               ...common_params

--- a/.github/workflows/pr-merge-develop-hato-bot.yml
+++ b/.github/workflows/pr-merge-develop-hato-bot.yml
@@ -16,6 +16,15 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Set org name
+        uses: actions/github-script@v6
+        if: env.REPO_NAME == github.repository
+        id: set_org_name
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          result-encoding: string
+          script:
+            return process.env.GITHUB_REPOSITORY.split('/')[0]
       - name: Get PullRequests
         uses: actions/github-script@v6
         id: get_pull_requests
@@ -25,7 +34,7 @@ jobs:
             const pulls_list_params = {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              head: "dev-hato:master",
+              head: "${{steps.set_org_name.outputs.result}}:master",
               base: "develop",
               state: "open"
             }
@@ -44,7 +53,7 @@ jobs:
               repo: context.repo.repo
             }
             const pulls_create_params = {
-              head: "dev-hato:master",
+              head: "${{steps.set_org_name.outputs.result}}:master",
               base: "develop",
               title: "master -> develop",
               body: "鳩の歴史は同期される\ndevelopに新たなコミットがpushされる前にマージしてね！",

--- a/.github/workflows/pr-merge-develop-hato-bot.yml
+++ b/.github/workflows/pr-merge-develop-hato-bot.yml
@@ -18,7 +18,6 @@ jobs:
           fetch-depth: 0
       - name: Set org name
         uses: actions/github-script@v6
-        if: env.REPO_NAME == github.repository
         id: set_org_name
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/pr-release-hato-bot.yml
+++ b/.github/workflows/pr-release-hato-bot.yml
@@ -23,6 +23,15 @@ jobs:
           result="${result//$'\n'/'%0A'}"
           result="${result//$'\r'/'%0D'}"
           echo "::set-output name=result::${result}"
+      - name: Set org name
+        uses: actions/github-script@v6
+        if: env.REPO_NAME == github.repository
+        id: set_org_name
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          result-encoding: string
+          script:
+            return process.env.GITHUB_REPOSITORY.split('/')[0]
       - name: Get PullRequests
         uses: actions/github-script@v6
         if: ${{ steps.get_diff.outputs.result != '' }}
@@ -33,7 +42,7 @@ jobs:
             const pulls_list_params = {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              head: "dev-hato:develop",
+              head: "${{steps.set_org_name.outputs.result}}:develop",
               base: "master",
               state: "open"
             }
@@ -53,7 +62,7 @@ jobs:
               repo: context.repo.repo
             }
             const pulls_create_params = {
-              head: "dev-hato:develop",
+              head: "${{steps.set_org_name.outputs.result}}:develop",
               base: "master",
               title: "リリース",
               body: "鳩は唐揚げになるため、片栗粉へ飛び込む",

--- a/.github/workflows/pr-release-hato-bot.yml
+++ b/.github/workflows/pr-release-hato-bot.yml
@@ -25,7 +25,6 @@ jobs:
           echo "::set-output name=result::${result}"
       - name: Set org name
         uses: actions/github-script@v6
-        if: env.REPO_NAME == github.repository
         id: set_org_name
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/pr-test-hato-bot.yml
+++ b/.github/workflows/pr-test-hato-bot.yml
@@ -77,7 +77,9 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
-      - run: echo "TAG_NAME=latest" >> "$GITHUB_ENV"
+      - run: |
+          echo "TAG_NAME=latest" >> "$GITHUB_ENV"
+          echo "REPOSITORY=${{github.repository}}" >> "${GITHUB_ENV}"
       - name: Build docker image
         run: docker-compose build --build-arg BUILDKIT_INLINE_CACHE=1
       - name: Start docker

--- a/.github/workflows/pr-update-pre-commit-config-hato-bot.yml
+++ b/.github/workflows/pr-update-pre-commit-config-hato-bot.yml
@@ -76,6 +76,15 @@ jobs:
           REPO_URL+="${{github.repository}}.git"
           GITHUB_HEAD="HEAD:refs/heads/fix-version-pre-commit-config-${HEAD_REF}"
           git push -f "${REPO_URL}" "${GITHUB_HEAD}"
+      - name: Set org name
+        uses: actions/github-script@v6
+        if: env.REPO_NAME == github.repository
+        id: set_org_name
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          result-encoding: string
+          script:
+            return process.env.GITHUB_REPOSITORY.split('/')[0]
       - name: Get PullRequests
         uses: actions/github-script@v6
         env:
@@ -90,7 +99,7 @@ jobs:
             const pulls_list_params = {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              head: "dev-hato:fix-version-pre-commit-config-" + HEAD_REF,
+              head: "${{steps.set_org_name.outputs.result}}:fix-version-pre-commit-config-" + HEAD_REF,
               base: HEAD_REF,
               state: "open"
             }
@@ -117,7 +126,7 @@ jobs:
             const pulls_create_params = {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              head: "dev-hato:fix-version-pre-commit-config-" + HEAD_REF,
+              head: "${{steps.set_org_name.outputs.result}}:fix-version-pre-commit-config-" + HEAD_REF,
               base: HEAD_REF,
               title,
               body: "鳩の唐揚げおいしい！😋😋😋 " + number
@@ -162,7 +171,7 @@ jobs:
               repo: context.repo.repo
             }
             const pulls_list_params = {
-              head: "dev-hato:" + head_name,
+              head: "${{steps.set_org_name.outputs.result}}:" + head_name,
               base: HEAD_REF,
               state: "open",
               ...common_params

--- a/.github/workflows/update_python-hato-bot.yml
+++ b/.github/workflows/update_python-hato-bot.yml
@@ -57,6 +57,15 @@ jobs:
           REPO_URL+="${{github.repository}}.git"
           GITHUB_HEAD="HEAD:refs/heads/fix-version-${HEAD_REF}-python-version"
           git push -f "${REPO_URL}" "${GITHUB_HEAD}"
+      - name: Set org name
+        uses: actions/github-script@v6
+        if: env.REPO_NAME == github.repository
+        id: set_org_name
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          result-encoding: string
+          script:
+            return process.env.GITHUB_REPOSITORY.split('/')[0]
       - name: Get PullRequests
         uses: actions/github-script@v5
         env:
@@ -71,7 +80,7 @@ jobs:
             const pulls_list_params = {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              head: "dev-hato:fix-version-" + HEAD_REF + "-python-version",
+              head: "${{steps.set_org_name.outputs.result}}:fix-version-" + HEAD_REF + "-python-version",
               base: HEAD_REF,
               state: "open"
             }
@@ -98,7 +107,7 @@ jobs:
             const pulls_create_params = {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              head: "dev-hato:fix-version-" + HEAD_REF + "-python-version",
+              head: "${{steps.set_org_name.outputs.result}}:fix-version-" + HEAD_REF + "-python-version",
               base: HEAD_REF,
               title,
               body: "鳩の唐揚げおいしい！😋😋😋 " + number
@@ -143,7 +152,7 @@ jobs:
               repo: context.repo.repo
             }
             const pulls_list_params = {
-              head: "dev-hato:" + head_name,
+              head: "${{steps.set_org_name.outputs.result}}:" + head_name,
               base: HEAD_REF,
               state: "open",
               ...common_params

--- a/.github/workflows/update_python.yml
+++ b/.github/workflows/update_python.yml
@@ -42,6 +42,15 @@ jobs:
           REPO_URL+="${{github.repository}}.git"
           GITHUB_HEAD="HEAD:refs/heads/fix-version-${HEAD_REF}-pipfile"
           git push -f "${REPO_URL}" "${GITHUB_HEAD}"
+      - name: Set org name
+        uses: actions/github-script@v6
+        if: env.REPO_NAME == github.repository
+        id: set_org_name
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          result-encoding: string
+          script:
+            return process.env.GITHUB_REPOSITORY.split('/')[0]
       - name: Get PullRequests
         uses: actions/github-script@v5
         env:
@@ -56,7 +65,7 @@ jobs:
             const pulls_list_params = {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              head: "dev-hato:fix-version-" + HEAD_REF + '-pipfile',
+              head: "${{steps.set_org_name.outputs.result}}:fix-version-" + HEAD_REF + '-pipfile',
               base: HEAD_REF,
               state: "open"
             }
@@ -83,7 +92,7 @@ jobs:
             const pulls_create_params = {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              head: "dev-hato:fix-version-" + HEAD_REF + '-pipfile',
+              head: "${{steps.set_org_name.outputs.result}}:fix-version-" + HEAD_REF + '-pipfile',
               base: HEAD_REF,
               title,
               body: "鳩の唐揚げおいしい！😋😋😋 " + number
@@ -128,7 +137,7 @@ jobs:
               repo: context.repo.repo
             }
             const pulls_list_params = {
-              head: "dev-hato:" + head_name,
+              head: "${{steps.set_org_name.outputs.result}}:" + head_name,
               base: HEAD_REF,
               state: "open",
               ...common_params

--- a/setup/docker-compose.yml
+++ b/setup/docker-compose.yml
@@ -19,9 +19,9 @@ services:
       dockerfile: ./Dockerfile
       context: ../
       cache_from:
-        - ghcr.io/dev-hato/hato-bot/hato-bot:${TAG_NAME}
-        - ghcr.io/dev-hato/hato-bot/hato-bot
-    image: ghcr.io/dev-hato/hato-bot/hato-bot:${TAG_NAME}
+        - ghcr.io/${REPOSITORY:-dev-hato/hato-bot}/hato-bot:${TAG_NAME}
+        - ghcr.io/${REPOSITORY:-dev-hato/hato-bot}/hato-bot
+    image: ghcr.io/${REPOSITORY:-dev-hato/hato-bot}/hato-bot:${TAG_NAME}
     platform: linux/amd64
     env_file:
       - ../.env


### PR DESCRIPTION
forkしたリポジトリ上でPRを立てた場合やforkしたリポジトリから本リポジトリへPRを出した場合にうまく動作するようにします。
forkしたリポジトリから本リポジトリへPRを出した場合はdockerイメージのpushをskipします。

また、リポジトリ名をできるだけ変数から取得するようにします。