### PR TITLE
releaseをトリガーとした場合はdocker imageのpushを無条件に行う

### DIFF
--- a/.github/workflows/pr-docker-hato-bot.yml
+++ b/.github/workflows/pr-docker-hato-bot.yml
@@ -18,7 +18,7 @@ jobs:
       COMPOSE_DOCKER_CLI_BUILD: 1
     permissions:
       packages: write
-    if: github.repository == github.event.pull_request.head.repo.full_name
+    if: github.event_name == 'release' || github.repository == github.event.pull_request.head.repo.full_name
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/actions/runs/1957836246

リリース時にdocker imageのpushが行われるようにします。