### PR TITLE
sudden-deathに同期するファイル調整

### DIFF
--- a/.github/workflows/pr-copy-ci-hato-bot.yml
+++ b/.github/workflows/pr-copy-ci-hato-bot.yml
@@ -39,7 +39,7 @@ jobs:
           find hato-bot/${worklows_path} -type f \
                                          -not -name "*hato-bot.yml" \
                                          -exec cp {} "${DEST_PATH}" \;
-          for f in .markdown-lint.yml .python-lint .textlintrc .gitleaks.toml .pre-commit-config.yaml .python-version package.json yarn.lock
+          for f in .markdown-lint.yml .python-lint .textlintrc .gitleaks.toml .mypy.ini .pre-commit-config.yaml .python-version
           do
             cp hato-bot/${f} sudden-death/
           done


### PR DESCRIPTION
sudden-deathに同期するファイルを以下のように調整します。
* `package.json`, `yarn.lock` 除外: `scripts` が異なるため、同期できない
* `.mypy.ini` 追加: 内容が同じになったため