### PR TITLE
lintコマンドの除外設定を設定ファイルに記述する

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -2,3 +2,4 @@
 
 [mypy]
 ignore_missing_imports = True
+exclude = ["^node_modules/"]

--- a/.python-lint
+++ b/.python-lint
@@ -14,7 +14,7 @@ ignore=CVS
 
 # Add files or directories matching the regex patterns to the blacklist. The
 # regex matches against base names, not paths.
-ignore-patterns=
+ignore-patterns=node_modules/.*
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
     "lint:markdown": "markdownlint -c .markdown-lint.yml -i node_modules .",
     "lint:text": "textlint -c .textlintrc $(find . -name '*.md' | grep -v node_modules)",
     "lint:sql": "pipenv run sqlfluff lint --config .sqlfluff",
-    "lint:python": "pipenv run pylint --rcfile .python-lint $(find . -name '*.py' | grep -v node_modules)",
-    "lint:python-type": "pipenv run mypy --config-file .mypy.ini --install-types --non-interactive $(find . -name '*.py' | grep -v node_modules)",
+    "lint:python": "pipenv run pylint --rcfile .python-lint *.py",
+    "lint:python-type": "pipenv run mypy --config-file .mypy.ini --install-types --non-interactive *.py",
     "lint:dockerfile": "hadolint -c .hadolint.yaml Dockerfile"
   },
   "devDependencies": {


### PR DESCRIPTION
lintコマンドでの `node_modules/` 除外の設定を可能な限り設定ファイルに記述するようにします。