### PR TITLE
pr-formatでPipfile.lockを正しい状態にする

### DIFF
--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -58,6 +58,7 @@ jobs:
       - name: Install dependencies
         run: |
           pipenv install --dev
+          pipenv lock
       # autopep8でformatする
       # --exit-codeをつけることで、autopep8内でエラーが起きれば1、差分があれば2のエラーステータスコードが返ってくる。正常時は0が返る
       - name: Format files


### PR DESCRIPTION
`pr-format` で `pipenv lock` を実行することで、 `Pipfile.lock` を正しい状態にします。