### PR TITLE
isort有効化

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -75,7 +75,6 @@ jobs:
           VALIDATE_ALL_CODEBASE: true
           VALIDATE_PYTHON_BLACK: false
           VALIDATE_JSCPD: false
-          VALIDATE_PYTHON_ISORT: false
           LINTER_RULES_PATH: .
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WORKON_HOME: ""

--- a/.python-lint
+++ b/.python-lint
@@ -1,12 +1,10 @@
 [MASTER]
+errors-only=
 
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
-# run arbitrary code.
+# run arbitrary code
 extension-pkg-whitelist=
-
-# Specify a score threshold to be exceeded before program exits with error.
-fail-under=10
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
@@ -20,24 +18,21 @@ ignore-patterns=node_modules/.*
 # pygtk.require().
 #init-hook=
 
-# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
-# number of processors available to use.
+# Use multiple processes to speed up Pylint.
 jobs=1
 
-# Control the amount of potential inferred values when inferring a single
-# object. This can help the performance when dealing with large functions or
-# complex, nested conditions.
-limit-inference-results=100
-
-# List of plugins (as comma separated values of python module names) to load,
+# List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
 load-plugins=
 
 # Pickle collected data for later comparisons.
 persistent=yes
 
+# Specify a configuration file.
+#rcfile=
+
 # When enabled, pylint would attempt to guess common misconfiguration and emit
-# user-friendly hints instead of false-positive error messages.
+# user-friendly hints instead of false-positive error messages
 suggestion-mode=yes
 
 # Allow loading of arbitrary C extensions. Extensions are imported into the
@@ -48,18 +43,18 @@ unsafe-load-any-extension=no
 [MESSAGES CONTROL]
 
 # Only show warnings with the listed confidence levels. Leave empty to show
-# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
 confidence=
 
 # Disable the message, report, category or checker with the given id(s). You
 # can either give multiple identifiers separated by comma (,) or put this
 # option multiple times (only on the command line, not in the configuration
-# file where it should appear only once). You can also use "--disable=all" to
+# file where it should appear only once).You can also use "--disable=all" to
 # disable everything first and then reenable specific checks. For example, if
 # you want to run only the similarities checker, you can use "--disable=all
 # --enable=similarities". If you want to run only the classes checker, but have
-# no Warning level messages displayed, use "--disable=all --enable=classes
-# --disable=W".
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
 disable=print-statement,
         parameter-unpacking,
         unpacking-in-except,
@@ -73,11 +68,11 @@ disable=print-statement,
         raw-checker-failed,
         bad-inline-option,
         locally-disabled,
+        locally-enabled,
         file-ignored,
         suppressed-message,
         useless-suppression,
         deprecated-pragma,
-        use-symbolic-message-instead,
         apply-builtin,
         basestring-builtin,
         buffer-builtin,
@@ -133,12 +128,7 @@ disable=print-statement,
         dict-items-not-iterating,
         dict-keys-not-iterating,
         dict-values-not-iterating,
-        deprecated-operator-function,
-        deprecated-urllib-function,
-        xreadlines-attribute,
-        deprecated-sys-function,
-        exception-escape,
-        comprehension-escape
+        import-error
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -149,27 +139,27 @@ enable=c-extension-no-member
 
 [REPORTS]
 
-# Python expression which should return a score less than or equal to 10. You
-# have access to the variables 'error', 'warning', 'refactor', and 'convention'
-# which contain the number of messages in each category, as well as 'statement'
-# which is the total number of statements analyzed. This score is used by the
-# global evaluation report (RP0004).
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
 evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
 
 # Template used to display messages. This is a python new-style format string
-# used to format the message information. See doc for all details.
+# used to format the message information. See doc for all details
 #msg-template=
 
 # Set the output format. Available formats are text, parseable, colorized, json
-# and msvs (visual studio). You can also give a reporter class, e.g.
+# and msvs (visual studio).You can also give a reporter class, eg
 # mypackage.mymodule.MyReporterClass.
 output-format=text
 
-# Tells whether to display a full report or only the messages.
+# Tells whether to display a full report or only the messages
 reports=no
 
 # Activate the evaluation score.
-score=yes
+score=no
 
 
 [REFACTORING]
@@ -181,183 +171,13 @@ max-nested-blocks=5
 # inconsistent-return-statements if a never returning function is called then
 # it will be considered as an explicit return statement and no message will be
 # printed.
-never-returning-functions=sys.exit
-
-
-[STRING]
-
-# This flag controls whether inconsistent-quotes generates a warning when the
-# character used as a quote delimiter is used inconsistently within a module.
-check-quote-consistency=no
-
-# This flag controls whether the implicit-str-concat should generate a warning
-# on implicit string concatenation in sequences defined over several lines.
-check-str-concat-over-line-jumps=no
-
-
-[MISCELLANEOUS]
-
-# List of note tags to take in consideration, separated by a comma.
-notes=FIXME,
-      XXX,
-      TODO
-
-# Regular expression of note tags to take in consideration.
-#notes-rgx=
-
-
-[SPELLING]
-
-# Limits count of emitted suggestions for spelling mistakes.
-max-spelling-suggestions=4
-
-# Spelling dictionary name. Available dictionaries: none. To make it work,
-# install the python-enchant package.
-spelling-dict=
-
-# List of comma separated words that should not be checked.
-spelling-ignore-words=
-
-# A path to a file that contains the private dictionary; one word per line.
-spelling-private-dict-file=
-
-# Tells whether to store unknown words to the private dictionary (see the
-# --spelling-private-dict-file option) instead of raising a message.
-spelling-store-unknown-words=no
-
-
-[BASIC]
-
-# Naming style matching correct argument names.
-argument-naming-style=snake_case
-
-# Regular expression matching correct argument names. Overrides argument-
-# naming-style.
-#argument-rgx=
-
-# Naming style matching correct attribute names.
-attr-naming-style=snake_case
-
-# Regular expression matching correct attribute names. Overrides attr-naming-
-# style.
-#attr-rgx=
-
-# Bad variable names which should always be refused, separated by a comma.
-bad-names=foo,
-          bar,
-          baz,
-          toto,
-          tutu,
-          tata
-
-# Bad variable names regexes, separated by a comma. If names match any regex,
-# they will always be refused
-bad-names-rgxs=
-
-# Naming style matching correct class attribute names.
-class-attribute-naming-style=any
-
-# Regular expression matching correct class attribute names. Overrides class-
-# attribute-naming-style.
-#class-attribute-rgx=
-
-# Naming style matching correct class names.
-class-naming-style=PascalCase
-
-# Regular expression matching correct class names. Overrides class-naming-
-# style.
-#class-rgx=
-
-# Naming style matching correct constant names.
-const-naming-style=UPPER_CASE
-
-# Regular expression matching correct constant names. Overrides const-naming-
-# style.
-#const-rgx=
-
-# Minimum line length for functions/classes that require docstrings, shorter
-# ones are exempt.
-docstring-min-length=-1
-
-# Naming style matching correct function names.
-function-naming-style=snake_case
-
-# Regular expression matching correct function names. Overrides function-
-# naming-style.
-#function-rgx=
-
-# Good variable names which should always be accepted, separated by a comma.
-good-names=i,
-           j,
-           k,
-           ex,
-           Run,
-           _
-
-# Good variable names regexes, separated by a comma. If names match any regex,
-# they will always be accepted
-good-names-rgxs=
-
-# Include a hint for the correct naming format with invalid-name.
-include-naming-hint=no
-
-# Naming style matching correct inline iteration names.
-inlinevar-naming-style=any
-
-# Regular expression matching correct inline iteration names. Overrides
-# inlinevar-naming-style.
-#inlinevar-rgx=
-
-# Naming style matching correct method names.
-method-naming-style=snake_case
-
-# Regular expression matching correct method names. Overrides method-naming-
-# style.
-#method-rgx=
-
-# Naming style matching correct module names.
-module-naming-style=snake_case
-
-# Regular expression matching correct module names. Overrides module-naming-
-# style.
-#module-rgx=
-
-# Colon-delimited sets of names that determine each other's naming style when
-# the name regexes allow several styles.
-name-group=
-
-# Regular expression which should only match function or class names that do
-# not require a docstring.
-no-docstring-rgx=^_
-
-# List of decorators that produce properties, such as abc.abstractproperty. Add
-# to this list to register other decorators that produce valid properties.
-# These decorators are taken in consideration only for invalid-name.
-property-classes=abc.abstractproperty
-
-# Naming style matching correct variable names.
-variable-naming-style=snake_case
-
-# Regular expression matching correct variable names. Overrides variable-
-# naming-style.
-#variable-rgx=
-
-
-[LOGGING]
-
-# The type of string formatting that logging methods do. `old` means using %
-# formatting, `new` is for `{}` formatting.
-logging-format-style=old
-
-# Logging modules to check that the string format arguments are in logging
-# function parameter format.
-logging-modules=logging
+never-returning-functions=optparse.Values,sys.exit
 
 
 [VARIABLES]
 
 # List of additional names supposed to be defined in builtins. Remember that
-# you should avoid defining new builtins when possible.
+# you should avoid to define new builtins when possible.
 additional-builtins=
 
 # Tells whether unused global variables should be treated as a violation.
@@ -368,12 +188,12 @@ allow-global-unused-variables=yes
 callbacks=cb_,
           _cb
 
-# A regular expression matching the name of dummy variables (i.e. expected to
-# not be used).
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
 dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
 
 # Argument names that match this expression will be ignored. Default to name
-# with leading underscore.
+# with leading underscore
 ignored-argument-names=_.*|^ignored_|^unused_
 
 # Tells whether we should check for unused import in __init__ files.
@@ -381,7 +201,14 @@ init-import=no
 
 # List of qualified module names which can have objects that can redefine
 # builtins.
-redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+redefining-builtins-modules=six.moves,past.builtins,future.builtins
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
 
 
 [TYPECHECK]
@@ -400,10 +227,6 @@ generated-members=
 # mixin class is detected if its name ends with "mixin" (case insensitive).
 ignore-mixin-members=yes
 
-# Tells whether to warn about missing members when the owner of the attribute
-# is inferred to be None.
-ignore-none=yes
-
 # This flag controls whether pylint should warn about no-member and similar
 # checks whenever an opaque object is returned when inferring. The inference
 # can return multiple potential results while evaluating a Python object, but
@@ -419,7 +242,7 @@ ignored-classes=optparse.Values,thread._local,_thread._local
 
 # List of module names for which member attributes should not be checked
 # (useful for modules/projects where namespaces are manipulated during runtime
-# and thus existing member attributes cannot be deduced by static analysis). It
+# and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
 ignored-modules=
 
@@ -435,8 +258,140 @@ missing-member-hint-distance=1
 # showing a hint for a missing member.
 missing-member-max-choices=1
 
-# List of decorators that change the signature of a decorated function.
-signature-mutators=
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+
+[BASIC]
+
+# Naming style matching correct argument names
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style
+#argument-rgx=
+
+# Naming style matching correct attribute names
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style
+#class-attribute-rgx=
+
+# Naming style matching correct class names
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-style
+#class-rgx=
+
+# Naming style matching correct constant names
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,
+            j,
+            k,
+            ex,
+            Run,
+            _
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style
+#inlinevar-rgx=
+
+# Naming style matching correct method names
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style
+#method-rgx=
+
+# Naming style matching correct module names
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style
+#variable-rgx=
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
 
 
 [FORMAT]
@@ -447,7 +402,7 @@ expected-line-ending-format=
 # Regexp for a line that is allowed to be longer than the limit.
 ignore-long-lines=^\s*((# )?<?https?://\S+>?|(from .* )?import .*)$
 
-# Number of spaces of indent required inside a hanging or continued line.
+# Number of spaces of indent required inside a hanging  or continued line.
 indent-after-paren=4
 
 # String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
@@ -457,15 +412,14 @@ indent-string='    '
 # Maximum number of characters on a single line.
 max-line-length=100
 
-# Maximum number of lines in a module.
+# Maximum number of lines in a module
 max-module-lines=1000
 
 # List of optional constructs for which whitespace checking is disabled. `dict-
 # separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
 # `trailing-comma` allows a space between comma and closing bracket: (a, ).
 # `empty-line` allows space-only lines.
-no-space-check=trailing-comma,
-               dict-separator
+no-space-check=trailing-comma,dict-separator
 
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.
@@ -493,19 +447,19 @@ min-similarity-lines=4
 
 [DESIGN]
 
-# Maximum number of arguments for function / method.
+# Maximum number of arguments for function / method
 max-args=5
 
 # Maximum number of attributes for a class (see R0902).
 max-attributes=7
 
-# Maximum number of boolean expressions in an if statement (see R0916).
+# Maximum number of boolean expressions in a if statement
 max-bool-expr=5
 
-# Maximum number of branch for function / method body.
+# Maximum number of branch for function / method body
 max-branches=12
 
-# Maximum number of locals for function / method body.
+# Maximum number of locals for function / method body
 max-locals=15
 
 # Maximum number of parents for a class (see R0901).
@@ -514,10 +468,10 @@ max-parents=7
 # Maximum number of public methods for a class (see R0904).
 max-public-methods=20
 
-# Maximum number of return / yield for function / method body.
+# Maximum number of return / yield for function / method body
 max-returns=6
 
-# Maximum number of statements in function / method body.
+# Maximum number of statements in function / method body
 max-statements=50
 
 # Minimum number of public methods for a class (see R0903).
@@ -525,10 +479,6 @@ min-public-methods=2
 
 
 [IMPORTS]
-
-# List of modules that can be imported at any level, not just the top level
-# one.
-allow-any-import-level=
 
 # Allow wildcard imports from modules that define __all__.
 allow-wildcard-with-all=no
@@ -538,19 +488,22 @@ allow-wildcard-with-all=no
 # only in one or another interpreter, leading to false positives when analysed.
 analyse-fallback-blocks=no
 
-# Deprecated modules which should not be used, separated by a comma.
-deprecated-modules=optparse,tkinter.tix
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,
+                  TERMIOS,
+                  Bastion,
+                  rexec
 
 # Create a graph of external dependencies in the given file (report RP0402 must
-# not be disabled).
+# not be disabled)
 ext-import-graph=
 
 # Create a graph of every (i.e. internal and external) dependencies in the
-# given file (report RP0402 must not be disabled).
+# given file (report RP0402 must not be disabled)
 import-graph=
 
 # Create a graph of internal dependencies in the given file (report RP0402 must
-# not be disabled).
+# not be disabled)
 int-import-graph=
 
 # Force import order to recognize a module as part of the standard
@@ -560,17 +513,13 @@ known-standard-library=
 # Force import order to recognize a module as part of a third party library.
 known-third-party=enchant
 
-# Couples of modules and preferred modules, separated by a comma.
-preferred-modules=
-
 
 [CLASSES]
 
 # List of method names used to declare (i.e. assign) instance attributes.
 defining-attr-methods=__init__,
                       __new__,
-                      setUp,
-                      __post_init__
+                      setUp
 
 # List of member names, which should be excluded from the protected access
 # warning.
@@ -584,12 +533,11 @@ exclude-protected=_asdict,
 valid-classmethod-first-arg=cls
 
 # List of valid names for the first argument in a metaclass class method.
-valid-metaclass-classmethod-first-arg=cls
+valid-metaclass-classmethod-first-arg=mcs
 
 
 [EXCEPTIONS]
 
 # Exceptions that will emit a warning when being caught. Defaults to
-# "BaseException, Exception".
-overgeneral-exceptions=BaseException,
-                       Exception
+# "Exception"
+overgeneral-exceptions=Exception

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY Pipfile Pipfile
 # * git: Pythonライブラリのインストールの際に必要
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git && \
-    pip install pipenv==2022.3.28 --no-cache-dir && \
+    pip install pipenv==2022.4.8 --no-cache-dir && \
     pipenv install --system --skip-lock && \
     pip uninstall -y pipenv virtualenv && \
     apt-get remove -y git && \

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -159,11 +159,11 @@
         },
         "fonttools": {
             "hashes": [
-                "sha256:236b29aee6b113e8f7bee28779c1230a86ad2aac9a74a31b0aedf57e7dfb62a4",
-                "sha256:2df636a3f402ef14593c6811dac0609563b8c374bd7850e76919eb51ea205426"
+                "sha256:59a90de72149893167e3d552ae2402c6874e006b9adc3feaf5f6d706fe20d392",
+                "sha256:b038d1a0dee0079de7ade57071e2e2aced6e35bd697de244ac62938b2b1628c1"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==4.31.2"
+            "version": "==4.32.0"
         },
         "frozenlist": {
             "hashes": [
@@ -647,11 +647,11 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea",
-                "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"
+                "sha256:7bf433498c016c4314268d95df76c81b842a4cb2b276fa3312cfb1e1d85f6954",
+                "sha256:ef7b523f6356f763771559412c0d7134753f037822dad1b16945b7b846f7ad06"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==3.0.7"
+            "markers": "python_full_version >= '3.6.8'",
+            "version": "==3.0.8"
         },
         "pyperclip": {
             "hashes": [
@@ -1146,11 +1146,11 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea",
-                "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"
+                "sha256:7bf433498c016c4314268d95df76c81b842a4cb2b276fa3312cfb1e1d85f6954",
+                "sha256:ef7b523f6356f763771559412c0d7134753f037822dad1b16945b7b846f7ad06"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==3.0.7"
+            "markers": "python_full_version >= '3.6.8'",
+            "version": "==3.0.8"
         },
         "pytest": {
             "hashes": [
@@ -1297,11 +1297,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:7999cbd87f1b6e1f33bf47efa368b224bed5e27b5ef2c4d46580186cbcb1a86a",
-                "sha256:a65e3802053e99fc64c6b3b29c11132943d5b8c8facbcc461157511546510967"
+                "sha256:26ead7d1f93efc0f8c804d9fafafbe4a44b179580a7105754b245155f9af05a8",
+                "sha256:47c7b0c0f8fc10eec4cf1e71c6fdadf8decaa74ffa087e68cd1c20db7ad6a592"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==62.0.0"
+            "version": "==62.1.0"
         },
         "six": {
             "hashes": [
@@ -1340,7 +1340,7 @@
                 "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
                 "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version < '3.11'",
             "version": "==2.0.1"
         },
         "tqdm": {

--- a/library/clientclass.py
+++ b/library/clientclass.py
@@ -5,8 +5,9 @@ clientに使うclass
 """
 import os
 from abc import ABCMeta, abstractmethod
-from slack import WebClient
+
 import slackbot_settings as conf
+from slack import WebClient
 
 
 class BaseClient(metaclass=ABCMeta):

--- a/library/database.py
+++ b/library/database.py
@@ -3,7 +3,6 @@ DBを操作するためのベースクラス
 """
 
 import psycopg2
-
 import slackbot_settings as conf
 
 

--- a/library/earthquake.py
+++ b/library/earthquake.py
@@ -5,7 +5,8 @@
 """
 
 import json
-from typing import Optional, Any
+from typing import Any, Optional
+
 import requests
 
 

--- a/library/geo.py
+++ b/library/geo.py
@@ -6,10 +6,9 @@ amesh
 
 import json
 import re
-from typing import Optional, Dict
+from typing import Dict, Optional
 
 import requests
-
 import slackbot_settings as conf
 
 

--- a/library/jma_amesh.py
+++ b/library/jma_amesh.py
@@ -4,13 +4,14 @@
 jma_amesh
 """
 
-from dataclasses import dataclass
-from io import BytesIO
-import random
-from string import Template
 import json
 import math
-from typing import Optional, List, Tuple
+import random
+from dataclasses import dataclass
+from io import BytesIO
+from string import Template
+from typing import List, Optional, Tuple
+
 import requests
 from PIL import Image, ImageEnhance
 

--- a/library/omikuji.py
+++ b/library/omikuji.py
@@ -4,9 +4,9 @@
 おみくじを返す
 """
 
-from typing import Tuple, TypeVar
 from dataclasses import dataclass
 from random import choices
+from typing import Tuple, TypeVar
 
 
 @dataclass

--- a/library/vocabularydb.py
+++ b/library/vocabularydb.py
@@ -3,7 +3,6 @@
 """
 
 import psycopg2
-
 from library.database import Database
 
 

--- a/plugins/analyze.py
+++ b/plugins/analyze.py
@@ -2,8 +2,9 @@
 メッセージを解析する
 """
 
-from typing import Callable
 from functools import partial
+from typing import Callable
+
 from library.clientclass import BaseClient
 from plugins import hato
 

--- a/plugins/hato.py
+++ b/plugins/hato.py
@@ -33,7 +33,6 @@ from library.vocabularydb import (
     show_vocabulary,
 )
 
-
 logger = getLogger(__name__)
 
 

--- a/plugins/hato.py
+++ b/plugins/hato.py
@@ -10,23 +10,28 @@ from enum import Enum, auto
 from logging import getLogger
 from tempfile import NamedTemporaryFile
 from typing import List
-import requests
-from git import Repo
-from git.exc import InvalidGitRepositoryError, GitCommandNotFound
-import pandas as pd
-import matplotlib.pyplot as plt
-import slackbot_settings as conf
 
-from library.vocabularydb \
-    import get_vocabularys, add_vocabulary, show_vocabulary, \
-    delete_vocabulary, show_random_vocabulary
+import matplotlib.pyplot as plt
+import pandas as pd
+import requests
+import slackbot_settings as conf
+from git import Repo
+from git.exc import GitCommandNotFound, InvalidGitRepositoryError
+from library.clientclass import BaseClient
 from library.earthquake import generate_quake_info_for_slack, get_quake_list
-from library.hukidasi import generator
 from library.geo import get_geo_data
 from library.hatokaraage import hato_ha_karaage
-from library.clientclass import BaseClient
+from library.hukidasi import generator
 from library.jma_amesh import jma_amesh
-from library.omikuji import OmikujiResult, OmikujiResults, draw as omikuji_draw
+from library.omikuji import OmikujiResult, OmikujiResults
+from library.omikuji import draw as omikuji_draw
+from library.vocabularydb import (
+    add_vocabulary,
+    delete_vocabulary,
+    get_vocabularys,
+    show_random_vocabulary,
+    show_vocabulary,
+)
 
 
 logger = getLogger(__name__)

--- a/run.py
+++ b/run.py
@@ -2,18 +2,19 @@
 
 """
 BotのMain関数
-"""
-import sys
+ """
 import logging
 import logging.config
-from typing import Callable, List
+import sys
 from concurrent.futures import ThreadPoolExecutor
-from slackeventsapi import SlackEventAdapter
-from flask import Flask, request, escape, jsonify
+from typing import Callable, List
+
 import slackbot_settings as conf
-from plugins import analyze
-from library.clientclass import SlackClient, ApiClient
+from flask import Flask, escape, jsonify, request
+from library.clientclass import ApiClient, SlackClient
 from library.database import Database
+from plugins import analyze
+from slackeventsapi import SlackEventAdapter
 
 app = Flask(__name__)
 

--- a/slackbot_settings.py
+++ b/slackbot_settings.py
@@ -8,7 +8,7 @@ import os
 import ssl
 import urllib.parse
 
-from dotenv import load_dotenv, find_dotenv
+from dotenv import find_dotenv, load_dotenv
 
 # .envファイルがあれば読み込む。存在しなければ環境変数から読み込む。
 load_dotenv(find_dotenv())

--- a/tests/library/test_geo.py
+++ b/tests/library/test_geo.py
@@ -5,7 +5,6 @@ import json
 import unittest
 
 import requests_mock
-
 import slackbot_settings as conf
 from library.geo import get_geo_data
 

--- a/tests/library/test_hatokaraage.py
+++ b/tests/library/test_hatokaraage.py
@@ -3,6 +3,7 @@
 """
 
 import unittest
+
 from library.hatokaraage import hato_ha_karaage
 
 

--- a/tests/library/test_hukidasi.py
+++ b/tests/library/test_hukidasi.py
@@ -2,8 +2,9 @@
 hukidashiライブラリのテスト
 """
 
-import unittest
 import textwrap
+import unittest
+
 from library.hukidasi import generator
 
 

--- a/tests/library/test_omikuji.py
+++ b/tests/library/test_omikuji.py
@@ -3,8 +3,8 @@ omikujiライブラリのテスト
 """
 
 import unittest
-
 from enum import Enum, auto
+
 from library.omikuji import OmikujiResult, OmikujiResults, draw
 
 

--- a/tests/plugins/test_analyze.py
+++ b/tests/plugins/test_analyze.py
@@ -4,8 +4,8 @@ analyze.pyのテスト
 
 import unittest
 
-from plugins.analyze import analyze_message
 from plugins import hato
+from plugins.analyze import analyze_message
 from tests.plugins import TestClient
 
 

--- a/tests/plugins/test_hato.py
+++ b/tests/plugins/test_hato.py
@@ -8,9 +8,15 @@ import unittest
 from typing import List
 
 import requests_mock
-
 import slackbot_settings as conf
-from plugins.hato import split_command, amesh, altitude, yoshiyoshi, omikuji, omikuji_results
+from plugins.hato import (
+    altitude,
+    amesh,
+    omikuji,
+    omikuji_results,
+    split_command,
+    yoshiyoshi,
+)
 from tests.library.test_geo import set_mock
 from tests.plugins import TestClient
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -4,8 +4,8 @@ run.pyのテスト
 
 import unittest
 
-from run import analyze_slack_message
 from plugins import hato
+from run import analyze_slack_message
 from tests.plugins import TestClient
 
 

--- a/wait_db.py
+++ b/wait_db.py
@@ -4,7 +4,6 @@ DBが起動するまで待機する
 from time import sleep
 
 import psycopg2
-
 from library.database import Database
 
 


### PR DESCRIPTION
https://github.com/github/super-linter/blob/786265439420ca117f198811ad9f3055b1a55c88/.github/linters/.python-lint
上記のpylintの設定を適用することで、isortと競合しないようになったので、isortを有効化します。