### PR TITLE
docstring周りの余分な差分を元に戻す

### DIFF
--- a/run.py
+++ b/run.py
@@ -2,7 +2,7 @@
 
 """
 BotのMain関数
- """
+"""
 import logging
 import logging.config
 import sys


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/pull/966 で変な差分が入っていたため元に戻します。