### PR TITLE
Dockerイメージビルド前にpullする

### DIFF
--- a/.github/workflows/pr-docker-hato-bot.yml
+++ b/.github/workflows/pr-docker-hato-bot.yml
@@ -42,7 +42,7 @@ jobs:
       - run: echo 'TAG_NAME=${{ github.event.release.tag_name }}' >> "$GITHUB_ENV"
         if: ${{ github.event_name == 'release' }}
       - run: echo "REPOSITORY=${{github.repository}}" >> "${GITHUB_ENV}"
-      - run: docker-compose pull
+      - run: docker compose pull
         continue-on-error: true
       - name: Build docker image
         run: docker-compose build --build-arg BUILDKIT_INLINE_CACHE=1

--- a/.github/workflows/pr-docker-hato-bot.yml
+++ b/.github/workflows/pr-docker-hato-bot.yml
@@ -42,6 +42,8 @@ jobs:
       - run: echo 'TAG_NAME=${{ github.event.release.tag_name }}' >> "$GITHUB_ENV"
         if: ${{ github.event_name == 'release' }}
       - run: echo "REPOSITORY=${{github.repository}}" >> "${GITHUB_ENV}"
+      - run: docker-compose pull
+        continue-on-error: true
       - name: Build docker image
         run: docker-compose build --build-arg BUILDKIT_INLINE_CACHE=1
       - run: docker-compose push


### PR DESCRIPTION
Dockerイメージビルド前にpullするとキャッシュが効きそうなので、pullするようにしてみます。
最初のCI実行時にはpullする対象がないはずなので、失敗しても処理を続行するようにしています。