### PR TITLE
pr-update-pre-commit-configをsudden_deathにも持っていく

### DIFF
--- a/.github/workflows/pr-update-pre-commit-config.yml
+++ b/.github/workflows/pr-update-pre-commit-config.yml
@@ -1,5 +1,5 @@
 ---
-name: pr-update-pre-commit-config-hato-bot
+name: pr-update-pre-commit-config
 
 on:
   pull_request:


### PR DESCRIPTION
`pr-update-pre-commit-config` は https://github.com/dev-hato/sudden-death にも適用可能な内容なので、 https://github.com/dev-hato/sudden-death にも持っていきます。