### PR TITLE
Python 3.11.0b1-slim-bullseyeをDependabotによるアップデート対象から除外

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: python
+        versions:
+          - 3.11.0b1-slim-bullseye
     open-pull-requests-limit: 1
   - package-ecosystem: github-actions
     directory: "/"


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/pull/1012 はベータ版であるため、Dependabotによるアップデート対象から除外します。