### PR TITLE
Dockerのビルド時間改善

### DIFF
--- a/.github/workflows/pr-docker-hato-bot.yml
+++ b/.github/workflows/pr-docker-hato-bot.yml
@@ -47,7 +47,14 @@ jobs:
       - run: echo 'TAG_NAME=${{ github.event.release.tag_name }}' >> "$GITHUB_ENV"
         if: ${{ github.event_name == 'release' }}
       - run: echo "REPOSITORY=${{github.repository}}" >> "${GITHUB_ENV}"
-      - name: Build and push
+      - name: Build and push (build)
+        uses: docker/bake-action@v2.0.0
+        env:
+          DOCKER_CONTENT_TRUST: 1
+        with:
+          push: true
+          files: build.docker-compose.yml
+      - name: Build and push (main)
         uses: docker/bake-action@v2.0.0
         env:
           DOCKER_CONTENT_TRUST: 1

--- a/.github/workflows/pr-docker-hato-bot.yml
+++ b/.github/workflows/pr-docker-hato-bot.yml
@@ -53,7 +53,6 @@ jobs:
           DOCKER_CONTENT_TRUST: 1
         with:
           push: true
-          pull: true
           files: docker-compose.yml
       - run: |
           docker compose up -d

--- a/build.docker-compose.yml
+++ b/build.docker-compose.yml
@@ -1,0 +1,18 @@
+---
+version: "3.7"
+services:
+  commit-hash:
+    build:
+      dockerfile: ./Dockerfile
+      context: .
+      target: commit-hash
+      cache_from:
+        - ghcr.io/${REPOSITORY:-dev-hato/hato-bot}/commit-hash:${TAG_NAME}
+        - ghcr.io/${REPOSITORY:-dev-hato/hato-bot}/commit-hash
+      args:
+        BUILDKIT_INLINE_CACHE: 1
+      x-bake:
+        platforms:
+          - linux/amd64
+    image: ghcr.io/${REPOSITORY:-dev-hato/hato-bot}/commit-hash:${TAG_NAME}
+    platform: linux/amd64

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       cache_from:
         - ghcr.io/${REPOSITORY:-dev-hato/hato-bot}/postgres:${TAG_NAME}
         - ghcr.io/${REPOSITORY:-dev-hato/hato-bot}/postgres
+        - ghcr.io/${REPOSITORY:-dev-hato/hato-bot}/commit-hash:${TAG_NAME}
+        - ghcr.io/${REPOSITORY:-dev-hato/hato-bot}/commit-hash
       args:
         BUILDKIT_INLINE_CACHE: 1
       x-bake:
@@ -33,6 +35,8 @@ services:
       cache_from:
         - ghcr.io/${REPOSITORY:-dev-hato/hato-bot}/hato-bot:${TAG_NAME}
         - ghcr.io/${REPOSITORY:-dev-hato/hato-bot}/hato-bot
+        - ghcr.io/${REPOSITORY:-dev-hato/hato-bot}/commit-hash:${TAG_NAME}
+        - ghcr.io/${REPOSITORY:-dev-hato/hato-bot}/commit-hash
       args:
         BUILDKIT_INLINE_CACHE: 1
       x-bake:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,6 @@ services:
       cache_from:
         - ghcr.io/${REPOSITORY:-dev-hato/hato-bot}/postgres:${TAG_NAME}
         - ghcr.io/${REPOSITORY:-dev-hato/hato-bot}/postgres
-        - ghcr.io/${REPOSITORY:-dev-hato/hato-bot}/commit-hash:${TAG_NAME}
-        - ghcr.io/${REPOSITORY:-dev-hato/hato-bot}/commit-hash
       args:
         BUILDKIT_INLINE_CACHE: 1
       x-bake:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       cache_from:
         - ghcr.io/${REPOSITORY:-dev-hato/hato-bot}/postgres:${TAG_NAME}
         - ghcr.io/${REPOSITORY:-dev-hato/hato-bot}/postgres
+      args:
+        BUILDKIT_INLINE_CACHE: 1
       x-bake:
         platforms:
           - linux/amd64
@@ -31,6 +33,8 @@ services:
       cache_from:
         - ghcr.io/${REPOSITORY:-dev-hato/hato-bot}/hato-bot:${TAG_NAME}
         - ghcr.io/${REPOSITORY:-dev-hato/hato-bot}/hato-bot
+      args:
+        BUILDKIT_INLINE_CACHE: 1
       x-bake:
         platforms:
           - linux/amd64


### PR DESCRIPTION
Dockerイメージのビルドに時間がかかりすぎているので修正します。
* 中間ステージをリポジトリにおくことで、キャッシュとして使えるようにする
* 常に最新のイメージをpullすると時間がかかりそうなので `pull: true` 削除
* `BUILDKIT_INLINE_CACHE=1` 設定