### PR TITLE
Buildxのセットアップ時にDOCKER_CONTENT_TRUST=1をセットしないようにする

### DIFF
--- a/.github/workflows/pr-docker-hato-bot.yml
+++ b/.github/workflows/pr-docker-hato-bot.yml
@@ -38,8 +38,6 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2
-        env:
-          DOCKER_CONTENT_TRUST: 1
       - run: echo "TAG_NAME=${HEAD_REF//\//-}" >> "$GITHUB_ENV"
         env:
           HEAD_REF: ${{github.head_ref}}


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/runs/6637260601?check_suite_focus=true#step:6:137

```
  Warning: docker: Error: remote trust data does not exist for docker.io/moby/buildkit: notary.docker.io does not have trust data for docker.io/moby/buildkit.
  See 'docker run --help'.
```

上記のWarningを解消するため、Buildxのセットアップ時に `DOCKER_CONTENT_TRUST=1` をセットしないようにします。