### PR TITLE
dotenv-linterをsuper-linterと並列で実行する

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -79,5 +79,14 @@ jobs:
           WORKON_HOME: ""
           PYTHONPATH: ${{ env.PYTHONPATH }}
           PATH: /github/workspace/node_modules/.bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/node_modules/.bin:/venvs/ansible-lint/bin:/venvs/black/bin:/venvs/cfn-lint/bin:/venvs/cpplint/bin:/venvs/flake8/bin:/venvs/isort/bin:/venvs/mypy/bin:/venvs/pylint/bin:/venvs/snakefmt/bin:/venvs/snakemake/bin:/venvs/sqlfluff/bin:/venvs/yamllint/bin:/venvs/yq/bin:/var/cache/dotnet/tools:/usr/share/dotnet
+
+  pr-dotenv-linter:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: "recursive"
+          fetch-depth: 0
       - name: Lint dotenv
         uses: dotenv-linter/action-dotenv-linter@v2.16.0


### PR DESCRIPTION
`dotenv-linter` を `super-linter` 実行後に実行する必然性もないので、並列で実行するようにします。