### PR TITLE
docker compose up -dでコンテナが全て起動完了するまで待つようにする

### DIFF
--- a/.github/workflows/pr-docker-hato-bot.yml
+++ b/.github/workflows/pr-docker-hato-bot.yml
@@ -284,7 +284,7 @@ jobs:
       - run: echo "REPOSITORY=${{github.repository}}" >> "${GITHUB_ENV}"
       - run: docker compose pull
       - name: Start docker
-        run: docker compose up -d
+        run: docker compose up -d --wait
       # Dockerコンテナ立ち上げから2分以内に疎通できるようになるかテストする
       - name: Test
         run: |

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@
 
     ```sh
     export TAG_NAME=$(git symbolic-ref --short HEAD | sed -e "s:/:-:g")
-    docker compose up -d
+    docker compose up -d --wait
     cd ..
     ```
 


### PR DESCRIPTION
`docker compose up -d` に `--wait` をつけることで、コンテナが全て起動完了するまで待つようにします。