### PR TITLE
Dockerコンテナの疎通テストの処理簡略化

### DIFF
--- a/.github/workflows/pr-docker-hato-bot.yml
+++ b/.github/workflows/pr-docker-hato-bot.yml
@@ -285,29 +285,9 @@ jobs:
       - run: docker compose pull
       - name: Start docker
         run: docker compose up -d --wait
-      # Dockerコンテナ立ち上げから2分以内に疎通できるようになるかテストする
+      # Dockerコンテナに疎通できるかテストする
       - name: Test
-        run: |
-          cmd="curl -XPOST -d '{\"message\": \"help\"}'"
-          cmd+=" -H \"Content-Type: application/json\""
-          cmd+=" http://localhost:3000/healthcheck"
-          cmd_="${cmd} -w '%{http_code}' -o /dev/null -s"
-          start_unixtime=$(date +%s)
-
-          while [ "$(echo "$(date +%s) - ${start_unixtime}" | bc)" -lt 120 ] \
-                && (! (docker compose ps | grep -q Exit))
-          do
-            if [ "$(eval "${cmd_}")" = 200 ] && eval "${cmd}"
-            then
-              docker compose logs
-              exit 0
-            fi
-
-            sleep 1
-          done
-
-          docker compose logs
-          exit 1
+        run: curl http://localhost:3000/status
 
   dockle:
     runs-on: ubuntu-latest


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/pull/1068 を行った場合、 `Start docker` 完了時点で疎通しているのが正になるので、Dockerコンテナの疎通テストの実行回数を1回にします。
また、使用するエンドポイントをより適切な `/status` に変更しています。