### PR TITLE
pr-update-pre-commit-configでactions/setup-nodeを使うようにする

### DIFF
--- a/.github/workflows/pr-update-pre-commit-config.yml
+++ b/.github/workflows/pr-update-pre-commit-config.yml
@@ -16,6 +16,9 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/setup-node@v3.3.0
+        with:
+          cache: yarn
       - name: Install packages
         run: yarn add js-yaml
       - name: Update .pre-commit-config.yaml


### PR DESCRIPTION
CI `pr-update-pre-commit-config` で `actions/setup-node` を使うようにします。