### PR TITLE
PRを出すCIをPRに関連する部分以外pushでも動かす

### DIFF
--- a/.github/workflows/pr-check-yarn.yml
+++ b/.github/workflows/pr-check-yarn.yml
@@ -3,6 +3,9 @@ name: pr-check-yarn
 
 on:
   pull_request:
+  push:
+    branches:
+      - master
 
 permissions:
   contents: write
@@ -35,7 +38,8 @@ jobs:
         run: |
           result=$(git diff)
           echo "::set-output name=result::$result"
-      - run: |
+      - if: github.event_name == 'pull_request'
+        run: |
           REPO_NAME="${{ github.event.pull_request.head.repo.full_name }}"
           echo "REPO_NAME=${REPO_NAME}" >> "${GITHUB_ENV}"
       # 差分があったときは、コミットを作りpushする
@@ -43,7 +47,8 @@ jobs:
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ env.REPO_NAME == github.repository
-          && steps.diff.outputs.result != '' }}
+          && steps.diff.outputs.result != ''
+          && github.event_name == 'pull_request' }}
         run: |
           git config user.name "github-actions[bot]"
           EMAIL="41898282+github-actions[bot]@users.noreply.github.com"
@@ -60,7 +65,8 @@ jobs:
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ env.REPO_NAME == github.repository
-          && steps.diff.outputs.result != '' }}
+          && steps.diff.outputs.result != ''
+          && github.event_name == 'pull_request' }}
         id: get_pull_requests
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -86,7 +92,8 @@ jobs:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ env.REPO_NAME == github.repository
           && steps.diff.outputs.result != ''
-          && steps.get_pull_requests.outputs.result == 0 }}
+          && steps.get_pull_requests.outputs.result == 0
+          && github.event_name == 'pull_request' }}
         id: create_pull_request
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -116,7 +123,8 @@ jobs:
           && steps.diff.outputs.result != ''
           && steps.get_pull_requests.outputs.result == 0
           && github.event.pull_request.user.login != 'dependabot[bot]'
-          && github.event.pull_request.user.login != 'renovate[bot]' }}
+          && github.event.pull_request.user.login != 'renovate[bot]'
+          && github.event_name == 'pull_request' }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -136,7 +144,8 @@ jobs:
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ env.REPO_NAME == github.repository
-          && steps.diff.outputs.result == '' }}
+          && steps.diff.outputs.result == ''
+          && github.event_name == 'pull_request' }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/pr-docker-hato-bot.yml
+++ b/.github/workflows/pr-docker-hato-bot.yml
@@ -87,7 +87,6 @@ jobs:
     env:
       DOCKER_CONTENT_TRUST: 1
     needs: deploy_docker_image
-    if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v3.0.2
         with:
@@ -117,7 +116,8 @@ jobs:
         run: |
           result=$(git diff)
           echo "::set-output name=result::$result"
-      - run: |
+      - if: github.event_name == 'pull_request'
+        run: |
           REPO_NAME="${{ github.event.pull_request.head.repo.full_name }}"
           echo "REPO_NAME=${REPO_NAME}" >> "${GITHUB_ENV}"
       # 差分があったときは、コミットを作りpushする
@@ -125,7 +125,8 @@ jobs:
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ env.REPO_NAME == github.repository
-          && steps.diff.outputs.result != '' }}
+          && steps.diff.outputs.result != ''
+          && github.event_name == 'pull_request' }}
         run: |
           git config user.name "github-actions[bot]"
           EMAIL="41898282+github-actions[bot]@users.noreply.github.com"
@@ -140,6 +141,7 @@ jobs:
       - name: Set org name
         uses: actions/github-script@v6.1.0
         if: env.REPO_NAME == github.repository
+          && github.event_name == 'pull_request'
         id: set_org_name
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -151,7 +153,8 @@ jobs:
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ env.REPO_NAME == github.repository
-          && steps.diff.outputs.result != '' }}
+          && steps.diff.outputs.result != ''
+          && github.event_name == 'pull_request' }}
         id: get_pull_requests
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -175,7 +178,8 @@ jobs:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ env.REPO_NAME == github.repository
           && steps.diff.outputs.result != ''
-          && steps.get_pull_requests.outputs.result == 0 }}
+          && steps.get_pull_requests.outputs.result == 0
+          && github.event_name == 'pull_request' }}
         id: create_pull_request
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -203,7 +207,8 @@ jobs:
           && steps.diff.outputs.result != ''
           && steps.get_pull_requests.outputs.result == 0
           && github.event.pull_request.user.login != 'dependabot[bot]'
-          && github.event.pull_request.user.login != 'renovate[bot]' }}
+          && github.event.pull_request.user.login != 'renovate[bot]'
+          && github.event_name == 'pull_request' }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -222,7 +227,8 @@ jobs:
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ env.REPO_NAME == github.repository
-          && steps.diff.outputs.result == '' }}
+          && steps.diff.outputs.result == ''
+          && github.event_name == 'pull_request' }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -4,6 +4,9 @@ name: pr-format
 # pull_requestで何かあった時に起動する
 on:
   pull_request:
+  push:
+    branches:
+      - master
 
 permissions:
   contents: write
@@ -74,7 +77,8 @@ jobs:
         run: |
           result=$(git diff)
           echo "::set-output name=result::$result"
-      - run: |
+      - if: github.event_name == 'pull_request'
+        run: |
           REPO_NAME="${{ github.event.pull_request.head.repo.full_name }}"
           echo "REPO_NAME=${REPO_NAME}" >> "${GITHUB_ENV}"
       # 差分があったときは、コミットを作りpushする
@@ -82,7 +86,8 @@ jobs:
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ env.REPO_NAME == github.repository
-          && steps.diff.outputs.result != '' }}
+          && steps.diff.outputs.result != ''
+          && github.event_name == 'pull_request' }}
         run: |
           git config user.name "github-actions[bot]"
           EMAIL="41898282+github-actions[bot]@users.noreply.github.com"
@@ -97,6 +102,7 @@ jobs:
       - name: Set org name
         uses: actions/github-script@v6.1.0
         if: env.REPO_NAME == github.repository
+          && github.event_name == 'pull_request'
         id: set_org_name
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -108,7 +114,8 @@ jobs:
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ env.REPO_NAME == github.repository
-          && steps.diff.outputs.result != '' }}
+          && steps.diff.outputs.result != ''
+          && github.event_name == 'pull_request' }}
         id: get_pull_requests
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -132,7 +139,8 @@ jobs:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ env.REPO_NAME == github.repository
           && steps.diff.outputs.result != ''
-          && steps.get_pull_requests.outputs.result == 0 }}
+          && steps.get_pull_requests.outputs.result == 0
+          && github.event_name == 'pull_request' }}
         id: create_pull_request
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -160,7 +168,8 @@ jobs:
           && steps.diff.outputs.result != ''
           && steps.get_pull_requests.outputs.result == 0
           && github.event.pull_request.user.login != 'dependabot[bot]'
-          && github.event.pull_request.user.login != 'renovate[bot]' }}
+          && github.event.pull_request.user.login != 'renovate[bot]'
+          && github.event_name == 'pull_request' }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -179,7 +188,8 @@ jobs:
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ env.REPO_NAME == github.repository
-          && steps.diff.outputs.result == '' }}
+          && steps.diff.outputs.result == ''
+          && github.event_name == 'pull_request' }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/pr-update-gitleaks.yml
+++ b/.github/workflows/pr-update-gitleaks.yml
@@ -3,6 +3,9 @@ name: pr-update-gitleaks
 
 on:
   pull_request:
+  push:
+    branches:
+      - master
 
 permissions:
   contents: write
@@ -67,7 +70,8 @@ jobs:
         run: |
           result=$(git diff .pre-commit-config.yaml .gitleaks.toml)
           echo "::set-output name=result::$result"
-      - run: |
+      - if: github.event_name == 'pull_request'
+        run: |
           REPO_NAME="${{ github.event.pull_request.head.repo.full_name }}"
           echo "REPO_NAME=${REPO_NAME}" >> "${GITHUB_ENV}"
       # 差分があったときは、コミットを作りpushする
@@ -75,7 +79,8 @@ jobs:
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ env.REPO_NAME == github.repository
-          && steps.diff.outputs.result != '' }}
+          && steps.diff.outputs.result != ''
+          && github.event_name == 'pull_request' }}
         run: |
           git config user.name "github-actions[bot]"
           EMAIL="41898282+github-actions[bot]@users.noreply.github.com"
@@ -90,6 +95,7 @@ jobs:
       - name: Set org name
         uses: actions/github-script@v6.1.0
         if: env.REPO_NAME == github.repository
+          && github.event_name == 'pull_request'
         id: set_org_name
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -101,7 +107,8 @@ jobs:
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ env.REPO_NAME == github.repository
-          && steps.diff.outputs.result != '' }}
+          && steps.diff.outputs.result != ''
+          && github.event_name == 'pull_request' }}
         id: get_pull_requests
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -125,7 +132,8 @@ jobs:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ env.REPO_NAME == github.repository
           && steps.diff.outputs.result != ''
-          && steps.get_pull_requests.outputs.result == 0 }}
+          && steps.get_pull_requests.outputs.result == 0
+          && github.event_name == 'pull_request' }}
         id: create_pull_request
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -153,7 +161,8 @@ jobs:
           && steps.diff.outputs.result != ''
           && steps.get_pull_requests.outputs.result == 0
           && github.event.pull_request.user.login != 'dependabot[bot]'
-          && github.event.pull_request.user.login != 'renovate[bot]' }}
+          && github.event.pull_request.user.login != 'renovate[bot]'
+          && github.event_name == 'pull_request' }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -172,7 +181,8 @@ jobs:
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ env.REPO_NAME == github.repository
-          && steps.diff.outputs.result == '' }}
+          && steps.diff.outputs.result == ''
+          && github.event_name == 'pull_request' }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |


### PR DESCRIPTION
renovateが出したPRに対してPRが出されていてもマージされるケースがあるようなので ( https://github.com/dev-hato/sudden-death/pull/275 )、PRを出すCIをPRに関連する部分以外pushでも動かすようにして、requiredにします。