### PR TITLE
CI内で使用しているパッケージをpackage.jsonに追加する

### DIFF
--- a/.github/workflows/pr-update-gitleaks.yml
+++ b/.github/workflows/pr-update-gitleaks.yml
@@ -24,7 +24,7 @@ jobs:
           npm_version=$(grep \"npm\" package.json \
                         | sed -e 's/ *"npm": "^\(.*\)"/\1/g')
           npm install --prefer-offline -g "npm@${npm_version}"
-          npm install --prefer-offline js-yaml
+          npm ci --prefer-offline
       - name: Update .gitleaks.toml
         run: |
           version="$(grep super-linter .github/workflows/pr-test.yml | grep uses | sed -e 's/.*@//g')"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "@proofdict/textlint-rule-proofdict": "3.1.2",
     "@textlint-ja/textlint-rule-no-insert-dropping-sa": "2.0.1",
+    "js-yaml": "^4.1.0",
     "markdownlint-cli": "0.31.1",
     "renovate": "32.100.3",
     "textlint": "12.2.1",


### PR DESCRIPTION
CI内で使用している `js-yaml` をpackage.jsonに追加します。
https://github.com/dev-hato/hato-bot/pull/1125 を前提としているので https://github.com/dev-hato/hato-bot/pull/1125 に向いています。