### PR TITLE
npmのバージョン取得処理をjqだけで記述する

### DIFF
--- a/.github/workflows/pr-check-npm.yml
+++ b/.github/workflows/pr-check-npm.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           cache: npm
       - run: |
-          npm_version=$(jq -r .engines.npm package.json | sed -e 's/^\^//g')
+          npm_version=$(jq -r '.engines.npm | ltrimstr("^")' package.json)
           npm install --prefer-offline --location=global "npm@${npm_version}"
           npm install
       # 差分があったときは差分を出力する
@@ -212,7 +212,7 @@ jobs:
           cache: npm
       - name: Install dependencies
         run: |
-          npm_version=$(jq -r .engines.npm package.json | sed -e 's/^\^//g')
+          npm_version=$(jq -r '.engines.npm | ltrimstr("^")' package.json)
           npm install --prefer-offline --location=global "npm@${npm_version}"
           npm install
       # 差分があったときは差分を出力する

--- a/.github/workflows/pr-renovate-config-validator.yml
+++ b/.github/workflows/pr-renovate-config-validator.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           cache: npm
       - run: |
-          npm_version=$(jq -r .engines.npm package.json | sed -e 's/^\^//g')
+          npm_version=$(jq -r '.engines.npm | ltrimstr("^")' package.json)
           npm install --prefer-offline --location=global "npm@${npm_version}"
           npm ci --prefer-offline
       - run: npx renovate-config-validator

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -64,7 +64,7 @@ jobs:
           cache: npm
       - name: Install dependencies
         run: |
-          npm_version=$(jq -r .engines.npm package.json | sed -e 's/^\^//g')
+          npm_version=$(jq -r '.engines.npm | ltrimstr("^")' package.json)
           npm install --prefer-offline --location=global "npm@${npm_version}"
           npm ci --prefer-offline
       - run: |

--- a/.github/workflows/pr-update-gitleaks.yml
+++ b/.github/workflows/pr-update-gitleaks.yml
@@ -21,7 +21,7 @@ jobs:
           cache: npm
       - name: Install packages
         run: |
-          npm_version=$(jq -r .engines.npm package.json | sed -e 's/^\^//g')
+          npm_version=$(jq -r '.engines.npm | ltrimstr("^")' package.json)
           npm install --prefer-offline --location=global "npm@${npm_version}"
           npm ci --prefer-offline
       - name: Update .gitleaks.toml


### PR DESCRIPTION
npmのバージョン取得処理をjqだけで記述できるとのことなので、jqだけで記述します。