### PR TITLE
package.jsonをsudden-deathに反映させる際に末尾に改行を入れる

### DIFF
--- a/.github/workflows/pr-copy-ci-hato-bot.yml
+++ b/.github/workflows/pr-copy-ci-hato-bot.yml
@@ -64,7 +64,7 @@ jobs:
                 suddenDeathPackage[packageKey] = hatoBotPackage[packageKey];
             }
 
-            fs.writeFileSync('./sudden-death/package.json', JSON.stringify(suddenDeathPackage, null, "  "), 'utf8');
+            fs.writeFileSync('./sudden-death/package.json', JSON.stringify(suddenDeathPackage, null, "  ") + "\n", 'utf8');
 
             delete hatoBotPackageLock.name;
 
@@ -72,7 +72,7 @@ jobs:
                 suddenDeathPackageLock[packageLockKey] = hatoBotPackageLock[packageLockKey];
             }
 
-            fs.writeFileSync('./sudden-death/package-lock.json', JSON.stringify(suddenDeathPackageLock, null, "  "), 'utf8');
+            fs.writeFileSync('./sudden-death/package-lock.json', JSON.stringify(suddenDeathPackageLock, null, "  ") + "\n", 'utf8');
       - name: Show diff
         id: show_diff
         working-directory: sudden-death


### PR DESCRIPTION
`package.json` や `package-lock.json` を https://github.com/dev-hato/sudden-death に反映させる際に末尾に改行を入っていないので入れます。