### PR TITLE
ameshのタイル画像取得時にUser Agentを付与する

### DIFF
--- a/library/jma_amesh.py
+++ b/library/jma_amesh.py
@@ -15,6 +15,8 @@ from typing import List, Optional, Tuple
 import requests
 from PIL import Image, ImageEnhance
 
+from slackbot_settings import VERSION
+
 
 @dataclass
 class WebMercatorTile:
@@ -94,7 +96,7 @@ def get_tile_image(
         )
     res = []
     for url in urls:
-        res.append(Image.open(BytesIO(requests.get(url).content)))
+        res.append(Image.open(BytesIO(requests.get(url, headers={'user-agent': f'hato-bot/{VERSION}'}).content)))
     dst_image = Image.new(
         "RGBA", (256 * (2 * around_tiles + 1), 256 * (2 * around_tiles + 1))
     )

--- a/library/jma_amesh.py
+++ b/library/jma_amesh.py
@@ -14,7 +14,6 @@ from typing import List, Optional, Tuple
 
 import requests
 from PIL import Image, ImageEnhance
-
 from slackbot_settings import VERSION
 
 
@@ -96,7 +95,15 @@ def get_tile_image(
         )
     res = []
     for url in urls:
-        res.append(Image.open(BytesIO(requests.get(url, headers={'user-agent': f'hato-bot/{VERSION}'}).content)))
+        res.append(
+            Image.open(
+                BytesIO(
+                    requests.get(
+                        url, headers={"user-agent": f"hato-bot/{VERSION}"}
+                    ).content
+                )
+            )
+        )
     dst_image = Image.new(
         "RGBA", (256 * (2 * around_tiles + 1), 256 * (2 * around_tiles + 1))
     )


### PR DESCRIPTION
https://operations.osmfoundation.org/policies/tiles/

>Valid [HTTP User-Agent](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent) identifying application. Faking another app’s User-Agent WILL get you blocked. Using a library’s default User-Agent is NOT recommended.

OSMにリクエストを投げる際にはUser Agentを指定しなければならないようなので (ただし公知のものである必要はない模様) User Agent付きで投げるようにします。