### PR TITLE
CI deployのファイル名とCI名を一致させる

### DIFF
--- a/.github/workflows/deploy-hato-bot.yml
+++ b/.github/workflows/deploy-hato-bot.yml
@@ -1,5 +1,5 @@
 ---
-name: deploy
+name: deploy-hato-bot
 
 on:
   release:


### PR DESCRIPTION
CI `deploy` のファイル名とCI名が異なっていてわかりづらいので一致させます。