### PR TITLE
blackとisortでフォーマットを整えるようにする

### DIFF
--- a/.github/workflows/pr-copy-ci-hato-bot.yml
+++ b/.github/workflows/pr-copy-ci-hato-bot.yml
@@ -39,7 +39,7 @@ jobs:
           find hato-bot/${worklows_path} -type f \
                                          -not -name "*hato-bot.yml" \
                                          -exec cp {} "${DEST_PATH}" \;
-          for f in .markdown-lint.yml .python-lint .textlintrc .gitleaks.toml .mypy.ini .pre-commit-config.yaml .python-version .pep8 .flake8 renovate.json
+          for f in .markdown-lint.yml .python-lint .textlintrc .gitleaks.toml .mypy.ini .pre-commit-config.yaml .python-version .pep8 .flake8 .python-black .isort.cfg renovate.json
           do
             cp hato-bot/${f} sudden-death/
           done

--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -64,12 +64,14 @@ jobs:
         run: pipenv --version
       - name: Install dependencies
         run: pipenv install --dev
-      # autopep8でformatする
+      # formatする
       # --exit-codeをつけることで、autopep8内でエラーが起きれば1、差分があれば2のエラーステータスコードが返ってくる。正常時は0が返る
       - name: Format files
         id: format
         run: |
           pipenv run autopep8 --exit-code --in-place --recursive .
+          pipenv run black --config .python-black --check .
+          pipenv run isort --sp .isort.cfg .
         continue-on-error: true
       - uses: dev-hato/actions-diff-pr-management@v1.0.1
         with:

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,8 @@
+[settings]
+profile=
+
+; vertical hanging indent mode also used in black configuration
+multi_line_output = 3
+
+; necessary because black expect the trailing comma
+include_trailing_comma = true

--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,8 @@ pylint = "==2.14.5"
 sqlfluff = "==1.2.1"
 mypy = "==0.971"
 flake8 = "*"
+black = "*"
+isort = "*"
 
 [packages]
 python-dotenv = "==0.20.0"


### PR DESCRIPTION
autopep8だけでなくblackとisortでもフォーマットを整えるようにします。
https://github.com/dev-hato/hato-bot/pull/1329 を前提としているため https://github.com/dev-hato/hato-bot/pull/1329 に向けています。