### PR TITLE
sudden-deathへのCIコピー時に意図しない項目が入らないようにする

### DIFF
--- a/.github/workflows/pr-copy-ci-hato-bot.yml
+++ b/.github/workflows/pr-copy-ci-hato-bot.yml
@@ -38,7 +38,7 @@ jobs:
 
           for f in $(find hato-bot/${worklows_path} -type f \
                                                     -not -name "*hato-bot.yml" | sed -e "s:hato-bot/${worklows_path}/::g"); do
-            yq '(.jobs.*.steps.[].with | select(has("repo-name")).repo-name) = "dev-hato/sudden-death"' "hato-bot/${worklows_path}/${f}" > "sudden-death/${worklows_path}/${f}"
+            yq '(.jobs.*.steps.[] | select(has("with")).with | select(has("repo-name")).repo-name) = "dev-hato/sudden-death"' "hato-bot/${worklows_path}/${f}" > "sudden-death/${worklows_path}/${f}"
           done
 
           for f in .markdown-lint.yml .python-lint .textlintrc .gitleaks.toml .mypy.ini .pre-commit-config.yaml .python-version .pep8 .flake8 .python-black .isort.cfg renovate.json


### PR DESCRIPTION
sudden-deathへのCIコピー時に `with` がないステップに `with: null` が追加されてしまうので修正します。