### PR TITLE
actions-update-gitleaksの不要な設定削除

### DIFF
--- a/.github/workflows/pr-update-gitleaks.yml
+++ b/.github/workflows/pr-update-gitleaks.yml
@@ -32,5 +32,4 @@ jobs:
       - uses: dev-hato/actions-update-gitleaks@v0.0.10
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
-          super-linter-yml-file: .github/workflows/pr-test.yml
           repo-name: dev-hato/hato-bot


### PR DESCRIPTION
`actions-update-gitleaks` v0.0.10では `super-linter-yml-file` の設定は不要なので削除します。