### PR TITLE
renovateのextendの順序変更

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "github>dev-hato/renovate-config",
-    "config:base"
+    "config:base",
+    "github>dev-hato/renovate-config"
   ]
 }


### PR DESCRIPTION
`dev-hato/renovate-config` を最後に適用する形にすることで、 `dev-hato/renovate-config` の設定が全て適用されるようにします。