### PR TITLE
Replace set-output by $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/deploy-hato-bot.yml
+++ b/.github/workflows/deploy-hato-bot.yml
@@ -126,7 +126,7 @@ jobs:
           DOCKER_CMD="python --version 2>&1 | sed -e 's/^Python //g'"
           python_version=$(docker compose run hato-bot sh -c "${DOCKER_CMD}")
           echo "Python version:" "${python_version}"
-          echo "::set-output name=python_version::${python_version}"
+          echo "python_version=${python_version}" >> $GITHUB_OUTPUT
       - name: Update versions
         run: |
           PYTHON_VERSION="${{steps.get_python_version.outputs.python_version}}"

--- a/.github/workflows/deploy-hato-bot.yml
+++ b/.github/workflows/deploy-hato-bot.yml
@@ -126,7 +126,7 @@ jobs:
           DOCKER_CMD="python --version 2>&1 | sed -e 's/^Python //g'"
           python_version=$(docker compose run hato-bot sh -c "${DOCKER_CMD}")
           echo "Python version:" "${python_version}"
-          echo "python_version=${python_version}" >> $GITHUB_OUTPUT
+          echo "python_version=${python_version}" >> "${GITHUB_OUTPUT}"
       - name: Update versions
         run: |
           PYTHON_VERSION="${{steps.get_python_version.outputs.python_version}}"

--- a/.github/workflows/pr-check-npm.yml
+++ b/.github/workflows/pr-check-npm.yml
@@ -31,7 +31,7 @@ jobs:
           DOCKER_CMD="npm --version"
           npm_version="$(docker run ghcr.io/dependabot/dependabot-core sh -c "${DOCKER_CMD}")"
           echo "npm version:" "${npm_version}"
-          echo "::set-output name=npm_version::${npm_version}"
+          echo "npm_version=${npm_version}" >> $GITHUB_OUTPUT
       - name: Update version
         run: |
           DEPENDABOT_NPM_VERSION="${{steps.get_dependabot_npm_version.outputs.npm_version}}"

--- a/.github/workflows/pr-check-npm.yml
+++ b/.github/workflows/pr-check-npm.yml
@@ -31,7 +31,7 @@ jobs:
           DOCKER_CMD="npm --version"
           npm_version="$(docker run ghcr.io/dependabot/dependabot-core sh -c "${DOCKER_CMD}")"
           echo "npm version:" "${npm_version}"
-          echo "npm_version=${npm_version}" >> $GITHUB_OUTPUT
+          echo "npm_version=${npm_version}" >> "${GITHUB_OUTPUT}"
       - name: Update version
         run: |
           DEPENDABOT_NPM_VERSION="${{steps.get_dependabot_npm_version.outputs.npm_version}}"

--- a/.github/workflows/pr-copy-ci-hato-bot.yml
+++ b/.github/workflows/pr-copy-ci-hato-bot.yml
@@ -80,7 +80,7 @@ jobs:
         working-directory: sudden-death
         run: |
           git add -A
-          echo "diff=$(git diff --cached)" >> $GITHUB_OUTPUT
+          echo "diff=$(git diff --cached)" >> "${GITHUB_OUTPUT}"
       - name: Push
         if: ${{ steps.show_diff.outputs.diff != '' }}
         working-directory: sudden-death

--- a/.github/workflows/pr-copy-ci-hato-bot.yml
+++ b/.github/workflows/pr-copy-ci-hato-bot.yml
@@ -80,7 +80,7 @@ jobs:
         working-directory: sudden-death
         run: |
           git add -A
-          echo "::set-output name=diff::$(git diff --cached)"
+          echo "diff=$(git diff --cached)" >> $GITHUB_OUTPUT
       - name: Push
         if: ${{ steps.show_diff.outputs.diff != '' }}
         working-directory: sudden-death

--- a/.github/workflows/pr-release-hato-bot.yml
+++ b/.github/workflows/pr-release-hato-bot.yml
@@ -22,7 +22,7 @@ jobs:
           echo "${result}"
           result="${result//$'\n'/'%0A'}"
           result="${result//$'\r'/'%0D'}"
-          echo "result=${result}" >> $GITHUB_OUTPUT
+          echo "result=${result}" >> "${GITHUB_OUTPUT}"
       - name: Set org name
         uses: actions/github-script@v6.3.2
         id: set_org_name

--- a/.github/workflows/pr-release-hato-bot.yml
+++ b/.github/workflows/pr-release-hato-bot.yml
@@ -22,7 +22,7 @@ jobs:
           echo "${result}"
           result="${result//$'\n'/'%0A'}"
           result="${result//$'\r'/'%0D'}"
-          echo "::set-output name=result::${result}"
+          echo "result=${result}" >> $GITHUB_OUTPUT
       - name: Set org name
         uses: actions/github-script@v6.3.2
         id: set_org_name


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
set-output が非推奨になるらしいので `$GITHUB_OUTPUT` に置き換えた

```bash
find .github -name '*.yml' -exec sed -i 's/echo "::set-output name=\([a-zA-Z0-9_]*\)::\(.*\)"$/echo "\1=\2" >> $GITHUB_OUTPUT/' {} \;
```