### PR TITLE
差分の改行文字・%をエスケープしてoutputに渡す

### DIFF
--- a/.github/workflows/pr-copy-ci-hato-bot.yml
+++ b/.github/workflows/pr-copy-ci-hato-bot.yml
@@ -80,7 +80,11 @@ jobs:
         working-directory: sudden-death
         run: |
           git add -A
-          echo "diff=$(git diff --cached)" >> "${GITHUB_OUTPUT}"
+          result="$(git diff --cached)"
+          result="${result//'%'/'%25'}"
+          result="${result//$'\n'/'%0A'}"
+          result="${result//$'\r'/'%0D'}"
+          echo "diff=${result}" >> "${GITHUB_OUTPUT}"
       - name: Push
         if: ${{ steps.show_diff.outputs.diff != '' }}
         working-directory: sudden-death


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/actions/runs/3246385456/jobs/5325150876

```
Error: Unable to process file command 'output' successfully.
Error: Invalid format 'index 6b19ec5..ca0e8fb 100644'
```

上記エラーが発生しないようにエスケープしてみます。
参考: https://gotohayato.com/content/558/