### PR TITLE
max-old-space-sizeを指定する

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,5 +51,6 @@ COPY .textlintrc .textlintrc
 COPY --from=commit-hash slackbot_settings.py slackbot_settings.py
 
 ENV GIT_PYTHON_REFRESH=quiet
+ENV NODE_OPTIONS "--max-old-space-size=2048"
 HEALTHCHECK --interval=5s --retries=20 CMD ["curl", "-s", "-S", "-o", "/dev/null", "http://localhost:3000/status"]
 CMD ["python", "entrypoint.py"]


### PR DESCRIPTION
```
<--- Last few GCs --->

[21:0x6d30700]    33360 ms: Scavenge 251.7 (257.8) -> 251.6 (258.5) MB, 6.6 / 0.0 ms  (average mu = 0.764, current mu = 0.443) allocation failure; 
[21:0x6d30700]    33838 ms: Mark-sweep 252.6 (258.5) -> 252.6 (258.5) MB, 459.9 / 0.0 ms  (average mu = 0.544, current mu = 0.173) allocation failure; scavenge might not succeed
[21:0x6d30700]    34384 ms: Mark-sweep 253.5 (258.5) -> 253.5 (260.5) MB, 508.4 / 0.0 ms  (average mu = 0.344, current mu = 0.069) allocation failure; scavenge might not succeed


<--- JS stacktrace --->

FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
 1: 0xb6e4e0 node::Abort() [node]
 2: 0xa7e632  [node]
 3: 0xd47d90 v8::Utils::ReportOOMFailure(v8::internal::Isolate*, char const*, bool) [node]
 4: 0xd48137 v8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, bool) [node]
 5: 0xf254f5  [node]
 6: 0xf379dd v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace, v8::internal::GarbageCollectionReason, v8::GCCallbackFlags) [node]
 7: 0xf120de v8::internal::HeapAllocator::AllocateRawWithLightRetrySlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [node]
 8: 0xf134a7 v8::internal::HeapAllocator::AllocateRawWithRetryOrFailSlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [node]
 9: 0xef467a v8::internal::Factory::NewFillerObject(int, v8::internal::AllocationAlignment, v8::internal::AllocationType, v8::internal::AllocationOrigin) [node]
10: 0x12b7c1f v8::internal::Runtime_AllocateInYoungGeneration(int, unsigned long*, v8::internal::Isolate*) [node]
11: 0x16e9879  [node]
```

Herokuでtextlintコマンドを実行すると `JavaScript heap out of memory` が発生するので、 `--max-old-space-size` を指定してみます。