### PR TITLE
nodeに割り当てるメモリを512MBにする

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,6 @@ COPY .textlintrc .textlintrc
 COPY --from=commit-hash slackbot_settings.py slackbot_settings.py
 
 ENV GIT_PYTHON_REFRESH=quiet
-ENV NODE_OPTIONS "--max-old-space-size=2048"
+ENV NODE_OPTIONS="--max-old-space-size=512"
 HEALTHCHECK --interval=5s --retries=20 CMD ["curl", "-s", "-S", "-o", "/dev/null", "http://localhost:3000/status"]
 CMD ["python", "entrypoint.py"]


### PR DESCRIPTION
nodeに割り当てるメモリをHerokuのメモリ上限と同じ512MBにします。