### PR TITLE
pipenvのバージョンを2022.10.25で固定する

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY Pipfile Pipfile
 # * libopencv-dev, libgl1-mesa-dev, libglib2.0-0: OpenCV
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git gcc libc6-dev libopencv-dev libgl1-mesa-dev libglib2.0-0 curl && \
-    pip install pipenv==2022.11.4 --no-cache-dir && \
+    pip install pipenv==2022.10.25 --no-cache-dir && \
     if [ "${ENV}" = 'dev' ]; then \
       pipenv install --system --skip-lock --dev; \
     else \

--- a/scripts/pr_format/pr_format/install_pipenv.sh
+++ b/scripts/pr_format/pr_format/install_pipenv.sh
@@ -12,14 +12,14 @@ fi
 
 pip install ${package_name_with_version}
 
-if [ -f ${file_name} ]; then
-  new_version="$(pip list --outdated | grep pipenv || true)"
-  new_version="$(echo -e "${new_version}" | awk '{print $3}')"
-  if [ -n "${new_version}" ]; then
-    PATTERN_BEFORE="${package_name}[^ ]+"
-    PATTERN_AFTER="${package_name}==${new_version}"
-    sed -i -E "s/${PATTERN_BEFORE}/${PATTERN_AFTER}/g" ${file_name}
-    pip install "${package_name}==${new_version}"
-    exit 1
-  fi
-fi
+#if [ -f ${file_name} ]; then
+#  new_version="$(pip list --outdated | grep pipenv || true)"
+#  new_version="$(echo -e "${new_version}" | awk '{print $3}')"
+#  if [ -n "${new_version}" ]; then
+#    PATTERN_BEFORE="${package_name}[^ ]+"
+#    PATTERN_AFTER="${package_name}==${new_version}"
+#    sed -i -E "s/${PATTERN_BEFORE}/${PATTERN_AFTER}/g" ${file_name}
+#    pip install "${package_name}==${new_version}"
+#    exit 1
+#  fi
+#fi


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/pull/1841#issuecomment-1304390378

```
AttributeError: 'VistirSpinner' object has no attribute '_color_func'
```

上記エラーを解消するため、 `pipenv` のバージョンを2022.10.25で固定します。

参考: https://stackoverflow.com/questions/74324063/pipenv-throws-and-error-when-installing-in-docker