### PR TITLE
py削除

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1359,14 +1359,6 @@
             "index": "pypi",
             "version": "==2.20.0"
         },
-        "py": {
-            "hashes": [
-                "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719",
-                "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==1.11.0"
-        },
         "pycodestyle": {
             "hashes": [
                 "sha256:2c9607871d58c76354b697b42f5d57e1ada7d261c261efac224b664affdc5785",


### PR DESCRIPTION
CVE-2022-42969 解消のため、 `py` を削除します。