### PR TITLE
textlintコマンド追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,25 +7,33 @@ RUN apt-get update \
 
 FROM python:3.11.0-slim-bullseye
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 ARG ENV
 ENV ENV="${ENV}"
 
 WORKDIR /usr/src/app
 
 COPY Pipfile Pipfile
+COPY package.json package.json
+COPY package-lock.json package-lock.json
 
 # 必要なパッケージ
 # * git, gcc, libc6-dev: Pythonライブラリのインストールの際に必要
 # * curl: ヘルスチェックの際に必要
 # * libopencv-dev, libgl1-mesa-dev, libglib2.0-0: OpenCV
+# * nodejs: textlintを使用する際に必要
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git gcc libc6-dev libopencv-dev libgl1-mesa-dev libglib2.0-0 curl && \
+    curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
+    apt-get install -y --no-install-recommends nodejs && \
     pip install pipenv==2022.11.11 --no-cache-dir && \
     if [ "${ENV}" = 'dev' ]; then \
       pipenv install --system --skip-lock --dev; \
     else \
       pipenv install --system --skip-lock; \
     fi && \
+    npm install && \
     pip uninstall -y pipenv virtualenv && \
     apt-get remove -y git gcc libc6-dev && \
     apt-get autoremove -y && \
@@ -40,8 +48,10 @@ COPY *.py ./
 COPY library library
 COPY plugins plugins
 COPY postgres/docker-entrypoint-initdb.d postgres/docker-entrypoint-initdb.d
+COPY .textlintrc .textlintrc
 COPY --from=commit-hash slackbot_settings.py slackbot_settings.py
 
 ENV GIT_PYTHON_REFRESH=quiet
+ENV NODE_OPTIONS="--max-old-space-size=512"
 HEALTHCHECK --interval=5s --retries=20 CMD ["curl", "-s", "-S", "-o", "/dev/null", "http://localhost:3000/status"]
 CMD ["python", "entrypoint.py"]

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ pipenv run pre-commit install
     標高 [text] ... 指定した地名・住所・郵便番号[text]の標高を表示する。
     標高 [緯度 (float)] [経度 (float)] ... 指定した座標([緯度 (float)], [経度 (float)])の標高を表示する。
     eq ... 最新の地震情報を3件表示する。
+    textlint [text] ... 文字列[text]を校正する。
     text list ... パワーワード一覧を表示する。
     text random ... パワーワードをひとつ、ランダムで表示する。
     text show [int] ... 指定した番号[int]のパワーワードを表示する。

--- a/commands.txt
+++ b/commands.txt
@@ -9,6 +9,7 @@ amedas [緯度 (float)] [経度 (float)] ... 指定した座標([緯度 (float)]
 標高 [text] ... 指定した地名・住所・郵便番号[text]の標高を表示する。
 標高 [緯度 (float)] [経度 (float)] ... 指定した座標([緯度 (float)], [経度 (float)])の標高を表示する。
 eq ... 最新の地震情報を3件表示する。
+textlint [text] ... 文字列[text]を校正する。
 text list ... パワーワード一覧を表示する。
 text random ... パワーワードをひとつ、ランダムで表示する。
 text show [int] ... 指定した番号[int]のパワーワードを表示する。

--- a/library/textlint.py
+++ b/library/textlint.py
@@ -1,0 +1,26 @@
+# coding: utf-8
+
+"""
+textlintを使って文章校正を行う
+"""
+
+import subprocess
+from typing import Optional
+
+
+def get_textlint_result(text: str) -> Optional[str]:
+    """textlintを使って文章校正を行う"""
+    # pylint: disable=W1510
+    process = subprocess.run(
+        ["/usr/src/app/node_modules/.bin/textlint", "--stdin"],
+        input=text,
+        encoding="UTF-8",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    for fd in [process.stderr, process.stdout]:
+        res = fd.strip()
+        if res:
+            return "```" + res + "```"
+
+    return None

--- a/plugins/analyze.py
+++ b/plugins/analyze.py
@@ -16,6 +16,7 @@ def analyze_message(message: str) -> Callable[[BaseClient], None]:
         "help": lambda m: hato.help_message,
         "eq": lambda m: hato.earth_quake,
         "地震": lambda m: hato.earth_quake,
+        "textlint": lambda m: hato.textlint(m[len("textlint ") :]),
         "text list": lambda m: hato.get_text_list,
         "text add ": lambda m: partial(hato.add_text, word=m[len("text add ") :]),
         "text show ": lambda m: partial(

--- a/plugins/hato.py
+++ b/plugins/hato.py
@@ -27,6 +27,7 @@ from library.jma_amedas import get_jma_amedas
 from library.jma_amesh import jma_amesh
 from library.omikuji import OmikujiResult, OmikujiResults
 from library.omikuji import draw as omikuji_draw
+from library.textlint import get_textlint_result
 from library.vocabularydb import (
     add_vocabulary,
     delete_vocabulary,
@@ -101,6 +102,21 @@ def earth_quake():
         msg = msg + generate_quake_info_for_slack(data, 3)
 
     return msg
+
+
+def textlint(text: str):
+    """文章を校正する"""
+
+    def ret(client: BaseClient):
+        msg = "完璧な文章っぽ!"
+        res = get_textlint_result(text)
+
+        if res:
+            msg = "文章の修正点をリストアップしたっぽ!\n" + res
+
+        client.post(msg)
+
+    return ret
 
 
 @action("text list")


### PR DESCRIPTION
元PR: https://github.com/dev-hato/hato-bot/pull/636
Revert https://github.com/dev-hato/hato-bot/pull/1717

textlintを使った文章校正を行うコマンドを追加します。
Herokuを使わないようにしたので行けるはず。