### PR TITLE
以下の -> 次の

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@
     docker compose up -d --wait
     ```
 
-    Docker内で開発用のPythonライブラリを使用したい場合は代わりに以下のコマンドを実行します。
+    Docker内で開発用のPythonライブラリを使用したい場合は代わりに次のコマンドを実行します。
 
     ```sh
     export TAG_NAME=$(git symbolic-ref --short HEAD | sed -e "s:/:-:g")
@@ -73,7 +73,7 @@
     docker compose restart
     ```
 
-    Docker内で開発用のPythonライブラリを使用したい場合は代わりに以下のコマンドを実行します。
+    Docker内で開発用のPythonライブラリを使用したい場合は代わりに次のコマンドを実行します。
 
     ```sh
     export TAG_NAME=$(git symbolic-ref --short HEAD | sed -e "s:/:-:g")

--- a/README.template.md
+++ b/README.template.md
@@ -59,7 +59,7 @@
     docker compose up -d --wait
     ```
 
-    Docker内で開発用のPythonライブラリを使用したい場合は代わりに以下のコマンドを実行します。
+    Docker内で開発用のPythonライブラリを使用したい場合は代わりに次のコマンドを実行します。
 
     ```sh
     export TAG_NAME=$(git symbolic-ref --short HEAD | sed -e "s:/:-:g")
@@ -73,7 +73,7 @@
     docker compose restart
     ```
 
-    Docker内で開発用のPythonライブラリを使用したい場合は代わりに以下のコマンドを実行します。
+    Docker内で開発用のPythonライブラリを使用したい場合は代わりに次のコマンドを実行します。
 
     ```sh
     export TAG_NAME=$(git symbolic-ref --short HEAD | sed -e "s:/:-:g")


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/actions/runs/3558456344/jobs/5977131286

```
/github/workspace/README.template.md
  62:41  ✓ error  以下の => 次の
書籍の場合は、以下ではなく次を利用します(常に下にあるとは限らないため)
See https://azu.github.io/proof-dictionary/#01BQ92YWWJ53P93ZZ2YMXDKF1D  @proofdict/proofdict
  76:41  ✓ error  以下の => 次の
書籍の場合は、以下ではなく次を利用します(常に下にあるとは限らないため)
See https://azu.github.io/proof-dictionary/#01BQ92YWWJ53P93ZZ2YMXDKF1D  @proofdict/proofdict
```

上記を修正します。