### PR TITLE
Postgresql 14へダウングレードする

### DIFF
--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:15.1-bullseye
+FROM postgres:14.6-bullseye
 
 RUN find / -type f -perm /u+s -ignore_readdir_race -exec chmod u-s {} \; && \
     find / -type f -perm /g+s -ignore_readdir_race -exec chmod g-s {} \;

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,13 @@
 {
   "extends": [
     "github>dev-hato/renovate-config"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "postgres"
+      ],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
```
$ docker compose logs
hato-bot-postgres-1  | 
hato-bot-postgres-1  | PostgreSQL Database directory appears to contain a database; Skipping initialization
hato-bot-postgres-1  | 
hato-bot-postgres-1  | 2022-11-28 12:23:46.415 UTC [1] FATAL:  database files are incompatible with server
hato-bot-postgres-1  | 2022-11-28 12:23:46.415 UTC [1] DETAIL:  The data directory was initialized by PostgreSQL version 14, which is not compatible with this version 15.1 (Debian 15.1-1.pgdg110+1).
```

Postgresql 14へダウングレードします。
合わせて、renovateによるPostgresqlのアップデートも一旦無効化します。