### PR TITLE
textlintコマンドを実行できるようDocker周り修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists ~/.cache /tmp && \
     find / -type f -perm /u+s -ignore_readdir_race -exec chmod u-s {} \; && \
     find / -type f -perm /g+s -ignore_readdir_race -exec chmod g-s {} \; && \
-    useradd -l -m -s /bin/bash -N -u "1000" "nonroot"
+    useradd -l -m -s /bin/bash -N -u "1000" "nonroot" && \
+    chown -R nonroot /usr/src/app
 USER nonroot
 
 COPY *.py ./

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
     env_file:
       - .env
     restart: always
+    # 本番環境ではコメントアウトする
     volumes:
       - .:/usr/src/app
     ports:


### PR DESCRIPTION
textlintコマンドを実行できるよう、以下のように修正します。
* `/usr/src/app` 以下の所有者を実行ユーザー ( `nonroot` ) にする
* 本番環境では `volumes` はコメントアウトする旨を `docker-compose.yml` に記述