### PR TITLE
textlintで三点リーダの連続を許容する

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -32,7 +32,8 @@
       "ja-no-successive-word": {
         "allow": [
             "人人",
-            "よし"
+            "よし",
+            "..."
         ]
       }
     },


### PR DESCRIPTION
`......` のような三点リーダの連続を許容します。