### PR TITLE
Yahoo! のアプリケーション登録リンクのURL死活チェックをignoreする

### DIFF
--- a/doc/02_Get_Yahoo_API_Token.md
+++ b/doc/02_Get_Yahoo_API_Token.md
@@ -1,8 +1,9 @@
 # Yahoo API Tokenを取得する
+※現在アプリケーションを登録できなくなっています。
 
 1. Yahoo! JAPAN IDを取得します。
 
-1. [新しいアプリケーションを開発](https://e.developer.yahoo.co.jp/register) で情報を入力します。
+1. <!-- textlint-disable no-dead-link -->[新しいアプリケーションを開発](https://e.developer.yahoo.co.jp/register)<!-- textlint-enable no-dead-link --> で情報を入力します。
     * アプリケーションの種類は `クライアントサイド` を選択します。
     * アプリケーション名は好きな名前を入力します。(例： `hato-bot` )
 


### PR DESCRIPTION
Yahoo! のアプリケーション登録リンクのURLが503を返すので、死活チェックを一旦ignoreにします。
また、登録できない旨をREADMEに追記しています。