### PR TITLE
ヘルスチェック削除

### DIFF
--- a/.github/workflows/deploy-hato-bot.yml
+++ b/.github/workflows/deploy-hato-bot.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Start docker
         env:
           DOCKER_CONTENT_TRUST: 1
-        run: bash "${GITHUB_WORKSPACE}/scripts/deploy_hato_bot/deploy_docker_image/test.sh"
+        run: docker compose up -d --wait
 
   # .python-version をDockerイメージと同期させる
   update-version-python-version:

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,5 +54,4 @@ COPY --from=commit-hash slackbot_settings.py slackbot_settings.py
 
 ENV GIT_PYTHON_REFRESH=quiet
 ENV NODE_OPTIONS="--max-old-space-size=512"
-HEALTHCHECK --interval=5s --retries=20 CMD ["curl", "-s", "-S", "-o", "/dev/null", "http://localhost:3000/status"]
 CMD ["python", "entrypoint.py"]

--- a/scripts/deploy_hato_bot/deploy_docker_image/test.sh
+++ b/scripts/deploy_hato_bot/deploy_docker_image/test.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-docker compose up -d --wait
-
-# Dockerコンテナに疎通できるかテストする
-curl http://localhost:3000/status

--- a/scripts/deploy_hato_bot/dockle/run_dockle.sh
+++ b/scripts/deploy_hato_bot/dockle/run_dockle.sh
@@ -13,6 +13,8 @@ for image_name in $(docker compose images | awk 'OFS=":" {print $2,$3}' | tail -
 
   if [[ "${image_name}" =~ "postgres" ]]; then
     cmd+="-ak key "
+  elif [[ "${image_name}" =~ "hato-bot" ]]; then
+    cmd+="-i CIS-DI-0006 "
   fi
 
   cmd+="${image_name}"


### PR DESCRIPTION
discordでは `/status` のエンドポイントが使えないため、Dockerイメージのヘルスチェックを削除します。
エンドポイント自体は何かの時に使えるかもしれないので残しておきます。