### PR TITLE
Dockerイメージから不要なファイル削除

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get update && \
     apt-get remove -y git gcc libc6-dev && \
     apt-get autoremove -y && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists ~/.cache /tmp && \
+    rm -rf /var/lib/apt/lists ~/.cache /tmp /root/.npm /usr/src/app/node_modules/re2/.github/actions/*/Dockerfile && \
     find / -type f -perm /u+s -ignore_readdir_race -exec chmod u-s {} \; && \
     find / -type f -perm /g+s -ignore_readdir_race -exec chmod g-s {} \; && \
     useradd -l -m -s /bin/bash -N -u "1000" "nonroot" && \


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/actions/runs/4335549665/jobs/7570241686

```
> dockle --exit-code 1 ghcr.io/dev-hato/hato-bot/hato-bot:massongit-patch-1
...
INFO	- DKL-LI-0003: Only put necessary files
	* Suspicious directory : root/.npm 
	* unnecessary file : usr/src/app/node_modules/re2/.github/actions/linux-alpine-node-16/Dockerfile 
	* unnecessary file : usr/src/app/node_modules/re2/.github/actions/linux-node-19/Dockerfile 
	* unnecessary file : usr/src/app/node_modules/re2/.github/actions/linux-node-12/Dockerfile 
	* unnecessary file : usr/src/app/node_modules/re2/.github/actions/linux-alpine-node-18/Dockerfile 
	* unnecessary file : usr/src/app/node_modules/re2/.github/actions/linux-node-18/Dockerfile 
	* unnecessary file : usr/src/app/node_modules/re2/.github/actions/linux-alpine-node-19/Dockerfile 
	* unnecessary file : usr/src/app/node_modules/re2/.github/actions/linux-alpine-node-14/Dockerfile
```

上記を解消します。