### PR TITLE
pylint設定修正

### DIFF
--- a/.python-lint
+++ b/.python-lint
@@ -467,4 +467,4 @@ valid-metaclass-classmethod-first-arg=mcs
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/actions/runs/4333401435/jobs/7566486644

```
pylint: Command line or configuration file:1: UserWarning: Specifying exception names in the overgeneral-exceptions option without module name is deprecated and support for it will be removed in pylint 3.0. Use fully qualified name (maybe 'builtins.Exception' ?) instead.
```

pylintの設定を修正します。