### PR TITLE
CodeQL修正

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/setup-python@v4.6.0
         with:
           python-version-file: .python-version
+          cache: pipenv
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,10 +25,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3.5.2
-        with:
-          # We must fetch at least the immediate parents so that if this is
-          # a pull request then we can checkout the head.
-          fetch-depth: 2
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -27,6 +27,8 @@ jobs:
         uses: actions/checkout@v3.5.2
       - name: Set up Python
         uses: actions/setup-python@v4.6.0
+        with:
+          python-version-file: .python-version
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3.5.2
+      - name: Set up Python
+        uses: actions/setup-python@v4.6.0
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,6 +1,9 @@
 ---
 name: "CodeQL"
 on:
+  push:
+    # The branches below must be a subset of the branches above
+    branches: [develop, master]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [develop, master]
@@ -26,10 +29,6 @@ jobs:
           # We must fetch at least the immediate parents so that if this is
           # a pull request then we can checkout the head.
           fetch-depth: 2
-      # If this run was triggered by a pull request event, then checkout
-      # the head of the pull request instead of the merge commit.
-      - run: git checkout HEAD^2
-        if: ${{ github.event_name == 'pull_request' }}
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,10 +2,8 @@
 name: "CodeQL"
 on:
   push:
-    # The branches below must be a subset of the branches above
     branches: [develop, master]
   pull_request:
-    # The branches below must be a subset of the branches above
     branches: [develop, master]
   schedule:
     - cron: '0 21 * * 0'


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/actions/runs/4801170915

```
2 issues were detected with this workflow: git checkout HEAD^2 is no longer necessary. Please remove this step as Code Scanning recommends analyzing the merge commit for best results. Please specify an on.push hook so that Code Scanning can compare pull requests against the state of the base branch.
```

```
An error occurred while trying to automatically install Python dependencies: Error: The process '/usr/bin/python3' failed with exit code 1
Please make sure any necessary dependencies are installed before calling the codeql-action/analyze step, and add a 'setup-python-dependencies: false' argument to this step to disable our automatic dependency installation and avoid this warning.
```

上記Warningを解消するため、以下を行います。

* `git checkout HEAD^2` 削除
* pushトリガー追加
* Python 3.11セットアップのため `setup-python` 追加