### PR TITLE
setup-pythonでpython-version-fileを指定する

### DIFF
--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           python-version-file: .python-version
           cache: pipenv
-      - run: echo {{ steps.setup_python.outputs.python-version }}
+      - run: echo ${{ steps.setup_python.outputs.python-version }}
       - name: Install pipenv
         id: install_pipenv
         continue-on-error: true

--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -28,6 +28,7 @@ jobs:
       - run: sed -i -e "s/python_version = \".*\"/python_version = \"$(sed -e 's/\([0-9]*\.[0-9]*\).*/\1/g' .python-version)\"/g" Pipfile
       - name: Set up Python
         uses: actions/setup-python@v4.6.0
+        id: setup_python
         with:
           python-version-file: .python-version
           cache: pipenv

--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -25,14 +25,13 @@ jobs:
           # submodule: 'recursive'
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
-      - run: sed -i -e "s/python_version = \".*\"/python_version = \"$(sed -e 's/\([0-9]*\.[0-9]*\).*/\1/g' .python-version)\"/g" Pipfile
       - name: Set up Python
         uses: actions/setup-python@v4.6.0
         id: setup_python
         with:
           python-version-file: .python-version
           cache: pipenv
-      - run: echo ${{ steps.setup_python.outputs.python-version }}
+      - run: sed -i -e "s/python_version = \".*\"/python_version = \"$(echo ${{ steps.setup_python.outputs.python-version }} | sed -e 's/\([0-9]*\.[0-9]*\).*/\1/g')\"/g" Pipfile
       - name: Install pipenv
         id: install_pipenv
         continue-on-error: true

--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           python-version-file: .python-version
           cache: pipenv
+      - run: echo {{ steps.setup_python.outputs.python-version }}
       - name: Install pipenv
         id: install_pipenv
         continue-on-error: true

--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -25,11 +25,11 @@ jobs:
           # submodule: 'recursive'
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
-      - run: bash "${GITHUB_WORKSPACE}/scripts/pr_format/pr_format/get_version.sh"
-      - name: Set up Python ${{ env.PYTHON_VERSION }}
+      - run: sed -i -e "s/python_version = \".*\"/python_version = \"$(sed -e 's/\([0-9]*\.[0-9]*\).*/\1/g' .python-version)\"/g" Pipfile
+      - name: Set up Python
         uses: actions/setup-python@v4.6.0
         with:
-          python-version: ${{env.PYTHON_VERSION }}
+          python-version-file: .python-version
           cache: pipenv
       - name: Install pipenv
         id: install_pipenv

--- a/.github/workflows/pr-test-hato-bot.yml
+++ b/.github/workflows/pr-test-hato-bot.yml
@@ -19,11 +19,10 @@ jobs:
       - uses: actions/checkout@v3.5.2
         with:
           submodules: "recursive"
-      - run: echo "PYTHON_VERSION=$(cat .python-version)" >> "${GITHUB_ENV}"
-      - name: Set up Python ${{ env.PYTHON_VERSION }}
+      - name: Set up Python
         uses: actions/setup-python@v4.6.0
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version-file: .python-version
           cache: pipenv
       - name: Test
         run: bash "${GITHUB_WORKSPACE}/scripts/pr_test_hato_bot/pr_test/test.sh"

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -14,11 +14,10 @@ jobs:
         with:
           submodules: "recursive"
           fetch-depth: 0
-      - run: echo "PYTHON_VERSION=$(cat .python-version)" >> "${GITHUB_ENV}"
-      - name: Set up Python ${{ env.PYTHON_VERSION }}
+      - name: Set up Python
         uses: actions/setup-python@v4.6.0
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version-file: .python-version
           cache: pipenv
       - name: Install pipenv
         env:

--- a/scripts/pr_format/pr_format/get_version.sh
+++ b/scripts/pr_format/pr_format/get_version.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-echo "PYTHON_VERSION=$(cat .python-version)" >> "${GITHUB_ENV}"
-sed -i -e "s/python_version = \".*\"/python_version = \"$(sed -e 's/\([0-9]*\.[0-9]*\).*/\1/g' .python-version)\"/g" Pipfile


### PR DESCRIPTION
https://github.com/actions/setup-python/releases/tag/v4.0.0

`actions/setup-python` v4.0.0でpython-version-fileを指定できるようになったので、 `.python-version` を指定する形式でバージョン指定を行うようにします。