### PR TITLE
pr-copy-ci修正

### DIFF
--- a/.github/workflows/pr-copy-ci-hato-bot.yml
+++ b/.github/workflows/pr-copy-ci-hato-bot.yml
@@ -14,10 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3.5.3
       - uses: actions/github-script@v6.4.1
-        id: set_org_name
         with:
           github-token: ${{secrets.SUDDEN_DEATH_CI_TOKEN}}
-          result-encoding: string
           script: |
             const script = require(`${process.env.GITHUB_WORKSPACE}/scripts/pr_copy_ci_hato_bot/pr_copy_ci/dispatch_event.js`)
             await script({ github, context })

--- a/.github/workflows/pr-copy-ci-hato-bot.yml
+++ b/.github/workflows/pr-copy-ci-hato-bot.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/github-script@v6.4.1
         id: set_org_name
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{secrets.SUDDEN_DEATH_CI_TOKEN}}
           result-encoding: string
           script: |
             const script = require(`${process.env.GITHUB_WORKSPACE}/scripts/pr_copy_ci_hato_bot/pr_copy_ci/dispatch_event.js`)

--- a/.github/workflows/pr-copy-ci-hato-bot.yml
+++ b/.github/workflows/pr-copy-ci-hato-bot.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - develop
+  workflow_dispatch:
 
 jobs:
   pr-copy-ci:

--- a/scripts/pr_copy_ci_hato_bot/pr_copy_ci/dispatch_event.js
+++ b/scripts/pr_copy_ci_hato_bot/pr_copy_ci/dispatch_event.js
@@ -1,7 +1,7 @@
 module.exports = async ({ github, context }) => {
   const reposCreateDispatchEventParams = {
     owner: context.repo.owner,
-    repo: context.repo.repo,
+    repo: 'sudden-death',
     event_type: 'pr-copy-ci'
   }
   console.log('call repos.createDispatchEvent:')


### PR DESCRIPTION
CI `pr-check-ci` を以下のように修正します。

* イベントの発火先のリポジトリ名をsudden-deathにする
* sudden-deathを触れるPersonal Access Tokenを与える
* 動作確認しやすいようworkflow_dispatchトリガー追加
* 不要な記述削除