### PR TITLE
renovate-config-validator: --strict付与

### DIFF
--- a/scripts/pr_renovate_config_validator/pr_renovate_config_validator/run_validator.sh
+++ b/scripts/pr_renovate_config_validator/pr_renovate_config_validator/run_validator.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 bash "${GITHUB_WORKSPACE}/scripts/npm_ci.sh"
-npx renovate-config-validator
+npx renovate-config-validator --strict


### PR DESCRIPTION
`renovate.json` のマイグレーションが必要な場合にCIが落ちるよう、 `renovate-config-validator` に `--strict` を付与します。