### PR TITLE
pr-copy-ci-hato-bot: workflow_dispatchイベントを発生させてsudden-death側のCIを実行する

### DIFF
--- a/scripts/pr_copy_ci_hato_bot/pr_copy_ci/dispatch_event.js
+++ b/scripts/pr_copy_ci_hato_bot/pr_copy_ci/dispatch_event.js
@@ -1,12 +1,13 @@
 module.exports = async ({ github, context }) => {
-  const reposCreateDispatchEventParams = {
+  const actionsCreateWorkflowDispatchParams = {
     owner: context.repo.owner,
     repo: 'sudden-death',
-    event_type: 'pr-copy-ci'
+    workflow_id: 2448946,
+    ref: 'main',
   }
-  console.log('call repos.createDispatchEvent:')
-  console.log(reposCreateDispatchEventParams)
-  await github.rest.repos.createDispatchEvent({
-    ...reposCreateDispatchEventParams
+  console.log('call actions.createWorkflowDispatch:')
+  console.log(actionsCreateWorkflowDispatchParams)
+  await github.rest.actions.createWorkflowDispatch({
+    ...actionsCreateWorkflowDispatchParams
   })
 }


### PR DESCRIPTION
 `repository_dispatch` イベントを発生させる方法でsudden-death側のCIを実行した場合、立てられたPRでCIが動作しないようなので、 `workflow_dispatch`  イベントを発生させる方法に変えてみます。

sudden-death側PR: https://github.com/dev-hato/sudden-death/pull/1774