### PR TITLE
renovate: flaskのバージョン指定追加

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,10 @@
   ],
   "packageRules": [
     {
+      "matchPackageNames": ["flask"],
+      "allowedVersions": "<3.0.0"
+    },
+    {
       "matchPackageNames": [
         "postgres"
       ],


### PR DESCRIPTION
https://github.com/slackapi/python-slack-events-api/blob/2884d7d21fea634d1e5e7926409ed87f6fcc14cf/setup.py#L37
slackeventsapiではflask 3系に対応していないため、3系にアップデートされないようにします。