### PR TITLE
pr-test: actions/checkoutのバージョン指定を他と揃える

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -42,7 +42,7 @@ jobs:
   pr-dotenv-linter:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           submodules: "recursive"
           fetch-depth: 0


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/blob/aee1db92b361a86641917d7d91956f80f46972b1/.github/workflows/pr-test.yml#L45

上記ではコメント内で `v4` が指定されていますが、この指定の場合、 https://github.com/dev-hato/hato-bot/pull/3370 のようにコミットハッシュを変えるという内容のアップデートPRが出て分かりづらいので、バージョンをピンポイントに指定するようなコメントに援交します。