### PR TITLE
Pipfile修正時にsetup.py内でimportしているパッケージは考慮しないようにする

### DIFF
--- a/scripts/pr_format/pr_format/fix_pipfile.py
+++ b/scripts/pr_format/pr_format/fix_pipfile.py
@@ -133,7 +133,7 @@ def get_imported_packages(project_root: Path) -> set[str]:
     imported_packages: set[str] = set()
 
     for file in project_root.glob("**/*.py"):
-        if "node_modules" in str(file):
+        if str(file).endswith("setup.py") or "node_modules" in str(file):
             continue
 
         with open(str(file), "r") as python_file:


### PR DESCRIPTION
`setup.py` 内でimportしているパッケージはPipfileのpackageセクションに追加されないようにします。
sudden-death側: https://github.com/dev-hato/sudden-death/pull/2027