### PR TITLE
README: MisskeyのAPIトークン発行についての記述修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@
 
     MISSKEY_API_TOKENにMisskeyのBotのアクセストークンを指定します。
 
-    MISSKEY_API_TOKENには `ドライブを操作する` と、 `ノートを作成・削除する` の権限が必要です。
+    MISSKEY_API_TOKENには `ドライブを操作する`, `ノートを作成・削除する`, `アカウントの情報を見る` の権限が必要です。
 
 6. docker composeで鳩botとPostgreSQLを起動します。
 

--- a/README.template.md
+++ b/README.template.md
@@ -64,7 +64,7 @@
 
     MISSKEY_API_TOKENにMisskeyのBotのアクセストークンを指定します。
 
-    MISSKEY_API_TOKENには `ドライブを操作する` と、 `ノートを作成・削除する` の権限が必要です。
+    MISSKEY_API_TOKENには `ドライブを操作する`, `ノートを作成・削除する`, `アカウントの情報を見る` の権限が必要です。
 
 6. docker composeで鳩botとPostgreSQLを起動します。
 


### PR DESCRIPTION
https://github.com/misskey-dev/misskey/blob/7ca0af9e7e2a325171d2f26414165078af5d5249/packages/backend/src/server/api/StreamingApiServerService.ts#L75-L77
上記により、MisskeyのAPIトークン発行時に `アカウントの情報を見る` の権限も付与しなければならなくなったので、そのようにREADMEを修正します。