### PR TITLE
Misskey投稿時のUTF-8絵文字変換処理をテキストがある場合のみ行う

### DIFF
--- a/library/clientclass.py
+++ b/library/clientclass.py
@@ -162,8 +162,11 @@ class MisskeyClient(BaseClient):
             self._post(file_ids=[drive_file["id"]])
 
     def _post(self, text=None, file_ids=None):
+        if text is not None:
+            text = emoji.emojize(text, language="alias")
+
         self.client.notes_create(
-            text=emoji.emojize(text, language="alias"),
+            text=text,
             reply_id=self.message["id"],
             file_ids=file_ids,
         )


### PR DESCRIPTION
```
hato-bot-hato-bot-1  | expected string or bytes-like object, got 'NoneType'
hato-bot-hato-bot-1  | Traceback (most recent call last):
hato-bot-hato-bot-1  |   File "/usr/src/app/run.py", line 243, in misskey_runner
hato-bot-hato-bot-1  |     analyze.analyze_message(
hato-bot-hato-bot-1  |   File "/usr/src/app/plugins/hato.py", line 54, in wrapper        
hato-bot-hato-bot-1  |     func(client, *args, **kwargs)
hato-bot-hato-bot-1  |   File "/usr/src/app/plugins/hato.py", line 497, in image_generate
hato-bot-hato-bot-1  |     client.upload(
hato-bot-hato-bot-1  |   File "/usr/src/app/library/clientclass.py", line 162, in upload 
hato-bot-hato-bot-1  |     self._post(file_ids=[drive_file["id"]])
hato-bot-hato-bot-1  |   File "/usr/src/app/library/clientclass.py", line 166, in _post  
hato-bot-hato-bot-1  |     text=emoji.emojize(text, language="alias"),
hato-bot-hato-bot-1  |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
hato-bot-hato-bot-1  |   File "/usr/local/lib/python3.12/site-packages/emoji/core.py", line 158, in emojize
hato-bot-hato-bot-1  |     return pattern.sub(replace, string)
hato-bot-hato-bot-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
hato-bot-hato-bot-1  | TypeError: expected string or bytes-like object, got 'NoneType' 
```

Misskey投稿時にテキストがない場合にもUTF-8絵文字変換処理を行うようになっていたので、そのような場合には行わないようにします。