### PR TITLE
setuid, setgidの権限削除の対象から一部パスを除外する

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,8 +43,8 @@ RUN apt-get update && \
     apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists ~/.cache /tmp /root/.npm /usr/src/app/node_modules/re2/.github/actions/*/Dockerfile && \
-    find / -type f -perm /u+s -ignore_readdir_race -exec chmod u-s {} \; && \
-    find / -type f -perm /g+s -ignore_readdir_race -exec chmod g-s {} \; && \
+    find / -type f -perm /u+s -ignore_readdir_race -not -path '/sys/devices/virtual/powercap/*' -exec chmod u-s {} \; && \
+    find / -type f -perm /g+s -ignore_readdir_race -not -path '/sys/devices/virtual/powercap/*' -exec chmod g-s {} \; && \
     useradd -l -m -s /bin/bash -N -u "1000" "nonroot" && \
     chown -R nonroot /usr/src/app
 USER nonroot


### PR DESCRIPTION
```
161.0 No schema files found: removed existing output file.
161.4 find: ‘/sys/devices/virtual/powercap/dtpm’: Permission denied
------
failed to solve: process "/bin/bash -o pipefail -c apt-get update &&     apt-get install -y --no-install-recommends git gcc libc6-dev libopencv-dev libgl1-mesa-dev libglib2.0-0 curl gnupg &&     mkdir -p /etc/apt/keyrings &&     curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg &&     echo \"deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main\" | tee /etc/apt/sources.list.d/nodesource.list &&     apt-get update &&     apt-get install -y --no-install-recommends nodejs &&     pip install pipenv==2023.11.15 --no-cache-dir &&     if [ \"${ENV}\" = 'dev' ]; then       pipenv install --system --skip-lock --dev;     else       pipenv install --system --skip-lock;     fi &&     npm install &&     pip uninstall -y pipenv virtualenv &&     apt-get remove -y git gcc libc6-dev gnupg &&     apt-get autoremove -y &&     apt-get clean &&     rm -rf /var/lib/apt/lists ~/.cache /tmp /root/.npm /usr/src/app/node_modules/re2/.github/actions/*/Dockerfile &&     find / -type f -perm /u+s -ignore_readdir_race -exec chmod u-s {} \\; &&     find / -type f -perm /g+s -ignore_readdir_race -exec chmod g-s {} \\; &&     useradd -l -m -s /bin/bash -N -u \"1000\" \"nonroot\" &&     chown -R nonroot /usr/src/app" did not complete successfully: exit code: 1
```

`setuid`, `setgid` の権限削除の対象から `/sys/devices/virtual/powercap/` 以下のファイルを除外します。