### PR TITLE
CI pr-format修正

### DIFF
--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -37,7 +37,6 @@ jobs:
         run: sed -i -e "s/python_version = \".*\"/python_version = \"$(echo ${{ steps.setup_python.outputs.python-version }} | sed -e 's/\([0-9]*\.[0-9]*\).*/\1/g')\"/g" Pipfile
       - name: Install pipenv
         id: install_pipenv
-        continue-on-error: true
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
         run: bash "${GITHUB_WORKSPACE}/scripts/pr_format/pr_format/install_pipenv.sh"
       - name: Install dependencies
@@ -49,8 +48,8 @@ jobs:
         id: format
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
         run: bash "${GITHUB_WORKSPACE}/scripts/pr_format/pr_format/format.sh"
-        continue-on-error: true
       - uses: dev-hato/actions-diff-pr-management@v1.1.7
+        if: success() || failure()
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           branch-name-prefix: fix-format

--- a/scripts/pr_format/pr_format/fix_pipfile.py
+++ b/scripts/pr_format/pr_format/fix_pipfile.py
@@ -140,7 +140,10 @@ def get_imported_packages(project_root: Path) -> set[str]:
             for imported_package in re.findall(
                 r"^(?:import|from)\s+(\w+)", python_file.read(), re.MULTILINE
             ):
-                if imported_package != 'sudden_death' and not is_std_or_local_lib(project_root, imported_package):
+                if (
+                    imported_package != 'sudden_death'
+                    and not is_std_or_local_lib(project_root, imported_package)
+                ):
                     imported_packages.add(imported_package)
 
     return imported_packages

--- a/scripts/pr_format/pr_format/fix_pipfile.py
+++ b/scripts/pr_format/pr_format/fix_pipfile.py
@@ -140,7 +140,7 @@ def get_imported_packages(project_root: Path) -> set[str]:
             for imported_package in re.findall(
                 r"^(?:import|from)\s+(\w+)", python_file.read(), re.MULTILINE
             ):
-                if not is_std_or_local_lib(project_root, imported_package):
+                if imported_package != 'sudden_death' and not is_std_or_local_lib(project_root, imported_package):
                     imported_packages.add(imported_package)
 
     return imported_packages


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/pull/3527 や https://github.com/dev-hato/hato-bot/pull/3533 をマージできるよう、CI `pr-format` を以下のように修正します。

* `sudden_death` をPipfile修正の対象外にする
* `dev-hato/actions-diff-pr-management` を前のstepが失敗した際にも実行する