### PR TITLE
CI pr-format: Pipfile内にパッケージがあるかを大文字・小文字区別せず判定する

### DIFF
--- a/scripts/pr_format/pr_format/fix_pipfile.py
+++ b/scripts/pr_format/pr_format/fix_pipfile.py
@@ -162,7 +162,8 @@ def get_pipfile_packages(pipfile: Pipfile) -> set[str] | NoReturn:
         if not is_pipfile_packages(pipfile_value):
             raise TypeError("Failed to cast to PipfilePackages: " + str(pipfile_value))
 
-        pipfile_packages |= set(pipfile_value.keys())
+        for package_name in pipfile_value.keys():
+            pipfile_packages.add(package_name.lower())
 
     return pipfile_packages
 
@@ -175,9 +176,8 @@ def exist_package_in_pipfile(packages: list[str], pipfile_packages: set[str]) ->
     :return: 与えられたパッケージ群のいずれかがPipfile内に存在するか
     """
     for package_name in packages:
-        for pn in [package_name, package_name.lower()]:
-            if pn in pipfile_packages:
-                return True
+        if package_name.lower() in pipfile_packages:
+            return True
 
     return False
 


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/pull/3533 や https://github.com/dev-hato/hato-bot/pull/3527 で修正PRが立たないようにするため、CI `pr-format` でPipfileを修正する際に、Pipfile内にパッケージがあるかを大文字・小文字区別せず判定するようにします。