### PR TITLE
CI pr-super-lint: DEFAULT_BRANCHを変数で与える

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -38,7 +38,7 @@ jobs:
           LINTER_RULES_PATH: .
           FILTER_REGEX_EXCLUDE: ".*assets/.*.txt"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DEFAULT_BRANCH: develop
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           WORKON_HOME: ""
           PYTHONPATH: ${{ env.PYTHONPATH }}
   pr-dotenv-linter:


### PR DESCRIPTION
CI `pr-super-lint` をそのままsudden-deathに持っていってもうまく動くように、 `DEFAULT_BRANCH` を変数で与えるようにします。