### PR TITLE
text list: MisskeyにおけるMarkdown修正

### DIFF
--- a/library/vocabularydb.py
+++ b/library/vocabularydb.py
@@ -70,7 +70,7 @@ def get_vocabularys():
             slack_msg = slack_msg + f"\n {cnt}. {text}"
             cnt += 1
 
-        slack_msg = slack_msg + "```"
+        slack_msg = slack_msg + "\n```"
 
         return slack_msg
     return "登録されている単語はないっぽ！"


### PR DESCRIPTION
Misskeyにおいて `text list` コマンドを実行した際に、コードブロックがコードブロックとして表示されないので、コードブロックを閉じる構文 (```) の前に改行を入れます。