### PR TITLE
Misskey: 受理した旨のリアクションを付けるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@
 
     MISSKEY_API_TOKENにMisskeyのBotのアクセストークンを指定します。
 
-    MISSKEY_API_TOKENには `ドライブを操作する`, `ノートを作成・削除する`, `アカウントの情報を見る` の権限が必要です。
+    MISSKEY_API_TOKENには `ドライブを操作する`, `ノートを作成・削除する`, `アカウントの情報を見る`, `リアクションを操作する` の権限が必要です。
 
 6. docker composeで鳩botとPostgreSQLを起動します。
 

--- a/README.template.md
+++ b/README.template.md
@@ -64,7 +64,7 @@
 
     MISSKEY_API_TOKENにMisskeyのBotのアクセストークンを指定します。
 
-    MISSKEY_API_TOKENには `ドライブを操作する`, `ノートを作成・削除する`, `アカウントの情報を見る` の権限が必要です。
+    MISSKEY_API_TOKENには `ドライブを操作する`, `ノートを作成・削除する`, `アカウントの情報を見る`, `リアクションを操作する` の権限が必要です。
 
 6. docker composeで鳩botとPostgreSQLを起動します。
 

--- a/library/clientclass.py
+++ b/library/clientclass.py
@@ -184,3 +184,6 @@ class MisskeyClient(BaseClient):
     def get_type():
         """misskey"""
         return "misskey"
+
+    def add_waiting_reaction(self):
+        self.client.notes_reactions_create(note_id=self.message["id"], reaction='👀')

--- a/run.py
+++ b/run.py
@@ -239,6 +239,7 @@ def main():
 
                                     if cred is not None and cred["id"] in mentions:
                                         client = MisskeyClient(misskey_client, note)
+                                        client.add_waiting_reaction()
                                         try:
                                             analyze.analyze_message(
                                                 note["text"]


### PR DESCRIPTION
Misskeyでコマンドを受理した際に、その旨がわかりやすいように👀のリアクションを付与するようにします (Discordのtyping相当)。
なお、この変更に伴い、Misskeyでのトークン発行時に `リアクションを操作する` の権限を追加で付与する必要があります。