### PR TITLE
Misskey: 投稿の公開範囲修正

### DIFF
--- a/library/clientclass.py
+++ b/library/clientclass.py
@@ -166,9 +166,14 @@ class MisskeyClient(BaseClient):
         if text is not None:
             text = emoji.emojize(text, language="alias")
 
+        visibility = self.message["visibility"]
+
+        if self.message["visibility"] == "public":
+            visibility = NoteVisibility.HOME
+
         self.client.notes_create(
             text=text,
-            visibility=NoteVisibility.HOME,
+            visibility=visibility,
             reply_id=self.message["id"],
             file_ids=file_ids,
         )


### PR DESCRIPTION
Misskeyでの投稿の公開範囲をパブリックでリプライが飛んできた場合はホームに、それ以外はリプライの公開範囲に準拠する形にします。
これにより、フォロワーやダイレクトで飛んできたリプライに対して、同じ投稿範囲で返せるようになります。