### PR TITLE
textlint-rule-terminologyアップデート

### DIFF
--- a/.github/workflows/pr-check-npm.yml
+++ b/.github/workflows/pr-check-npm.yml
@@ -30,6 +30,7 @@ jobs:
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
         with:
           cache: npm
+          node-version-file: package.json
       - name: Get npm version
         id: get_npm_version
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
@@ -56,6 +57,7 @@ jobs:
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
         with:
           cache: npm
+          node-version-file: package.json
       - name: Install dependencies
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
         run: bash "${GITHUB_WORKSPACE}/scripts/pr_check_npm/npm_install.sh"

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           cache: npm
+          node-version-file: package.json
       - name: Install dependencies
         run: bash "${GITHUB_WORKSPACE}/scripts/pr_test/pr_super_lint/npm_ci.sh"
       - name: Lint files

--- a/.github/workflows/pr-update-gitleaks.yml
+++ b/.github/workflows/pr-update-gitleaks.yml
@@ -26,6 +26,7 @@ jobs:
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
         with:
           cache: npm
+          node-version-file: package.json
       - name: Install packages
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
         run: bash "${GITHUB_WORKSPACE}/scripts/npm_ci.sh"

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "textlint-rule-prefer-tari-tari": "1.0.3",
         "textlint-rule-preset-ja-spacing": "2.4.3",
         "textlint-rule-preset-ja-technical-writing": "10.0.1",
-        "textlint-rule-terminology": "4.0.1"
+        "textlint-rule-terminology": "5.0.0"
       },
       "engines": {
         "npm": "^10.5.0 || ^8.19.2"
@@ -5859,9 +5859,9 @@
       }
     },
     "node_modules/textlint-rule-terminology": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/textlint-rule-terminology/-/textlint-rule-terminology-4.0.1.tgz",
-      "integrity": "sha512-wKiVhc2B9HP2MFU4x7ZDx+oM5u43ETpKWTLHKvdhPRZ0+davi4M8mFmkZVovDIMO7igsGjixikcvFmnCMg3kmQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/textlint-rule-terminology/-/textlint-rule-terminology-5.0.0.tgz",
+      "integrity": "sha512-z9RFKWTkt5m0fkEFwOYHq9QaMDsLc2dnNTZ5NybfW5oyp1iITPZOepV8EQYnrQJmPVgZflIpioUqzkDb0tUB8w==",
       "dev": true,
       "dependencies": {
         "lodash": "^4.17.15",
@@ -5869,7 +5869,7 @@
         "textlint-rule-helper": "^2.1.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/textlint-tester": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "textlint-rule-terminology": "5.0.0"
   },
   "engines": {
+    "node": ">=20",
     "npm": "^10.5.0 || ^8.19.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "textlint-rule-prefer-tari-tari": "1.0.3",
     "textlint-rule-preset-ja-spacing": "2.4.3",
     "textlint-rule-preset-ja-technical-writing": "10.0.1",
-    "textlint-rule-terminology": "4.0.1"
+    "textlint-rule-terminology": "5.0.0"
   },
   "engines": {
     "npm": "^10.5.0 || ^8.19.2"


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/pull/3887 をベースに `textlint-rule-terminology` をアップデートします。
Node.jsのバージョンを20以上にしています。