### PR TITLE
Matplotlib用のフォントキャッシュをビルド時に生成する

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,9 @@ RUN apt-get update && \
     chown -R nonroot /usr/src/app
 USER nonroot
 
+# Matplotlib用のフォントキャッシュ生成
+RUN python -c 'import matplotlib.pyplot'
+
 COPY *.py ./
 COPY library library
 COPY plugins plugins


### PR DESCRIPTION
```
hato-bot-1  | Matplotlib is building the font cache; this may take a moment.
```

Matplotlib用のフォントキャッシュを実行時に行っているので、これをビルド時にあらかじめ行うようにします。