### PR TITLE
docker-compose.yml: version削除

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 ---
-version: "3.8"
 volumes:
   postgres-data:
     driver: "local"


### PR DESCRIPTION
```
$ export TAG_NAME=$(git symbolic-ref --short HEAD | sed -e "s:/:-:g")
    docker compose up -d --wait
WARN[0000] /Users/elegantbelltree/Documents/hato-bot/docker-compose.yml: `version` is obsolete 
```

`version` は非推奨とのことなので削除します。