### PR TITLE
座標取得時に国土地理院のAPIを優先的に使う

### DIFF
--- a/library/geo.py
+++ b/library/geo.py
@@ -21,11 +21,11 @@ def get_geo_data(place: str) -> Optional[Dict[str, str]]:
     :return: place: 地名, lat: 緯度, lon: 経度
     """
 
-    geo_data = get_yahoo_geo_data(place)
+    geo_data = get_gsi_geo_data(place)
     if geo_data is not None:
         return geo_data
 
-    return get_gsi_geo_data(place)
+    return get_yahoo_geo_data(place)
 
 
 def get_yahoo_geo_data(place: str) -> Optional[Dict[str, str]]:

--- a/tests/plugins/test_hato.py
+++ b/tests/plugins/test_hato.py
@@ -21,7 +21,7 @@ from plugins.hato import (
     yoshiyoshi,
 )
 from plugins.hato_mikuji import HatoMikuji
-from tests.library.test_geo import set_yahoo_mock
+from tests.library.test_geo import set_gsi_mock
 from tests.plugins import TestClient
 
 
@@ -186,15 +186,17 @@ class TestAmesh(unittest.TestCase):
         引数なしでameshコマンドが実行できるかテスト
         """
         with requests_mock.Mocker() as mocker:
-            content = {
-                "Feature": [
-                    {
-                        "Name": "東京都世田谷区",
-                        "Geometry": {"Coordinates": "139.65324950,35.64657460"},
-                    }
-                ]
-            }
-            set_yahoo_mock("東京", mocker, False, content)
+            content = [
+                {
+                    "geometry": {
+                        "coordinates": [139.6532495, 35.6465746],
+                        "type": "Point",
+                    },
+                    "type": "Feature",
+                    "properties": {"addressCode": "", "title": "東京都世田谷区"},
+                },
+            ]
+            set_gsi_mock("東京", mocker, content)
             self.amesh_upload_png_test(
                 mocker, "", "東京都世田谷区の雨雲状況をお知らせするっぽ！"
             )
@@ -252,15 +254,17 @@ class TestAmedas(unittest.TestCase):
         引数なしでamedasコマンドが実行できるかテスト
         """
         with requests_mock.Mocker() as mocker:
-            content = {
-                "Feature": [
-                    {
-                        "Name": "東京都世田谷区",
-                        "Geometry": {"Coordinates": "139.65324950,35.64657460"},
-                    }
-                ]
-            }
-            set_yahoo_mock("東京", mocker, False, content)
+            content = [
+                {
+                    "geometry": {
+                        "coordinates": [139.6532495, 35.6465746],
+                        "type": "Point",
+                    },
+                    "type": "Feature",
+                    "properties": {"addressCode": "", "title": "東京都世田谷区"},
+                },
+            ]
+            set_gsi_mock("東京", mocker, content)
             self.get_amedas_test(
                 mocker,
                 "",
@@ -335,15 +339,17 @@ class TestAltitude(unittest.TestCase):
         """
         with requests_mock.Mocker() as mocker:
             coordinates = ["35.64657460", "139.65324950"]
-            geo_content = {
-                "Feature": [
-                    {
-                        "Name": "東京都世田谷区",
-                        "Geometry": {"Coordinates": ",".join(reversed(coordinates))},
-                    }
-                ]
-            }
-            set_yahoo_mock("東京", mocker, False, geo_content)
+            geo_content = [
+                {
+                    "geometry": {
+                        "coordinates": reversed(coordinates),
+                        "type": "Point",
+                    },
+                    "type": "Feature",
+                    "properties": {"addressCode": "", "title": "東京都世田谷区"},
+                },
+            ]
+            set_gsi_mock("東京", mocker, geo_content)
             altitude_setagaya = 35.4
             altitude_content = {
                 "Feature": [{"Property": {"Altitude": altitude_setagaya}}]

--- a/tests/plugins/test_hato.py
+++ b/tests/plugins/test_hato.py
@@ -338,11 +338,11 @@ class TestAltitude(unittest.TestCase):
         引数なしでaltitudeコマンドが実行できるかテスト
         """
         with requests_mock.Mocker() as mocker:
-            coordinates = ["35.64657460", "139.65324950"]
+            coordinates = [139.6532495, 35.6465746]
             geo_content = [
                 {
                     "geometry": {
-                        "coordinates": list(reversed(coordinates)),
+                        "coordinates": coordinates,
                         "type": "Point",
                     },
                     "type": "Feature",
@@ -354,7 +354,7 @@ class TestAltitude(unittest.TestCase):
             altitude_content = {
                 "Feature": [{"Property": {"Altitude": altitude_setagaya}}]
             }
-            client1 = self.altitude_test(mocker, "", coordinates, altitude_content)
+            client1 = self.altitude_test(mocker, "", [str(c) for c in reversed(coordinates)], altitude_content)
             self.assertEqual(
                 client1.get_post_message(),
                 f"東京都世田谷区の標高は{altitude_setagaya}mっぽ！",

--- a/tests/plugins/test_hato.py
+++ b/tests/plugins/test_hato.py
@@ -342,7 +342,7 @@ class TestAltitude(unittest.TestCase):
             geo_content = [
                 {
                     "geometry": {
-                        "coordinates": reversed(coordinates),
+                        "coordinates": list(reversed(coordinates)),
                         "type": "Point",
                     },
                     "type": "Feature",


### PR DESCRIPTION
Yahoo! APIより国土地理院のAPIの方が精度が良い場合があるので (例: `芦ノ湖` (箱根))、座標取得時に後者を優先的に使うようにします。