### PR TITLE
fly.ioへのデプロイ処理修正

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-DATABASE_URL=postgres://postgres:password@postgres:5432/
+DATABASE_URL=postgres://postgres:password@postgres:5432/?sslmode=require
 DISCORD_API_TOKEN=
 MISSKEY_API_TOKEN=
 MISSKEY_DOMAIN=

--- a/flyio_deploy.sh
+++ b/flyio_deploy.sh
@@ -1,17 +1,11 @@
 #!/usr/bin/env bash
-set -x
+set -xe -o pipefail
 
-# この時点では必要な環境変数がセットされていないため、起動に失敗する (コマンドが異常終了する)
-fly launch --copy-config --vm-memory=256mb -y
-
-set -e
-POSTGRES_APP_NAME="$(yq '.app' fly.toml)-db"
+APP_NAME=$(yq '.app' fly.toml)
+fly apps create --name="$APP_NAME"
+grep -v DATABASE_URL .env | fly secrets import
+POSTGRES_APP_NAME="${APP_NAME}-db"
 fly postgres create --name="$POSTGRES_APP_NAME" --region="$(yq '.primary_region' fly.toml)" --initial-cluster-size=1 \
 	--vm-size="$(yq '.vm.[0].size' fly.toml)" --volume-size=1
 fly postgres attach "$POSTGRES_APP_NAME"
-sleep 60
-grep -v DATABASE_URL .env | fly secrets import
-sleep 60
-
-# shellcheck disable=SC2046
-fly machine start $(fly machine list --json | yq '.[].id' | tr "\n" ' ')
+fly deploy --vm-memory=256mb

--- a/flyio_deploy.sh
+++ b/flyio_deploy.sh
@@ -8,4 +8,4 @@ POSTGRES_APP_NAME="${APP_NAME}-db"
 fly postgres create --name="$POSTGRES_APP_NAME" --region="$(yq '.primary_region' fly.toml)" --initial-cluster-size=1 \
 	--vm-size="$(yq '.vm.[0].size' fly.toml)" --volume-size=1
 fly postgres attach "$POSTGRES_APP_NAME"
-fly deploy --vm-memory=256mb
+fly deploy --vm-memory=256

--- a/library/database.py
+++ b/library/database.py
@@ -12,7 +12,7 @@ class Database:
 
     def __init__(self):
         try:
-            self.conn = psycopg2.connect(conf.DB_URL, sslmode="require")
+            self.conn = psycopg2.connect(conf.DB_URL)
         except psycopg2.Error as _e:
             print("Can not connect to database.")
             raise _e


### PR DESCRIPTION
fly.ioへのデプロイ処理を空のアプリに環境変数をセット後デプロイする形にすることで、コマンドが失敗しないようにしました。
また、fly.ioでは `DATABASE_URL` 内に `sslmode=disable` が含まれているので、開発環境での `sslmode=require` も `DATABASE_URL` 内で設定するようにします。