### PR TITLE
fly.io: アプリのメモリ容量をfly.tomlに記述する

### DIFF
--- a/fly.template.toml
+++ b/fly.template.toml
@@ -20,3 +20,4 @@ primary_region = 'nrt'
 
 [[vm]]
   size = 'shared-cpu-1x'
+  memory = '256'

--- a/flyio_deploy.sh
+++ b/flyio_deploy.sh
@@ -8,4 +8,4 @@ POSTGRES_APP_NAME="${APP_NAME}-db"
 fly postgres create --name="$POSTGRES_APP_NAME" --region="$(yq '.primary_region' fly.toml)" --initial-cluster-size=1 \
 	--vm-size="$(yq '.vm.[0].size' fly.toml)" --volume-size=1
 fly postgres attach "$POSTGRES_APP_NAME"
-fly deploy --vm-memory=256
+fly deploy


### PR DESCRIPTION
fly.ioのアプリのメモリ容量を `fly.toml` に記述します。
どうやら、数値だけの文字列であれば良いみたいです。