### PR TITLE
fly.toml: internal_portをデフォルトポートにする

### DIFF
--- a/fly.template.toml
+++ b/fly.template.toml
@@ -11,7 +11,7 @@ primary_region = 'nrt'
 [build]
 
 [http_service]
-  internal_port = 8080
+  internal_port = 3000
   force_https = true
   auto_stop_machines = true
   auto_start_machines = true


### PR DESCRIPTION
`fly.toml` の `internal_port` をデフォルトポートにしてSlackで使えるようにします。