### PR TITLE
DockerイメージにインストールするNode.jsアップデート

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ ENV ENV="${ENV}"
 
 WORKDIR /usr/src/app
 
+COPY .npmrc .npmrc
 COPY Pipfile Pipfile
 COPY package.json package.json
 COPY package-lock.json package-lock.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends git gcc libc6-dev libopencv-dev libgl1-mesa-dev libglib2.0-0 curl gnupg && \
     mkdir -p /etc/apt/keyrings && \
     curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
-    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends nodejs && \
     pip install pipenv==2023.12.1 --no-cache-dir && \


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/pull/3891 の漏れ。
DockerイメージにインストールするNode.jsをアップデートします。
また、こちらのアップデートが漏れていた場合に `npm install` が失敗するよう、 `.npmrc` をDockerイメージに追加します。