### PR TITLE
pipenvアップデート処理を一時的に削除

### DIFF
--- a/scripts/pr_format/pr_format/install_pipenv.sh
+++ b/scripts/pr_format/pr_format/install_pipenv.sh
@@ -11,15 +11,3 @@ else
 fi
 
 pip install "${package_name_with_version}"
-
-if [ -f ${file_name} ]; then
-	new_version="$(pip list --outdated | grep pipenv || true)"
-	new_version="$(echo -e "${new_version}" | awk '{print $3}')"
-	if [ -n "${new_version}" ]; then
-		PATTERN_BEFORE="${package_name}[^ ]+"
-		PATTERN_AFTER="${package_name}==${new_version}"
-		sed -i -E "s/${PATTERN_BEFORE}/${PATTERN_AFTER}/g" ${file_name}
-		pip install "${package_name}==${new_version}"
-		exit 1
-	fi
-fi


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/actions/runs/9437719483/job/25994118763

```
#36 73.30 [pipenv.exceptions.InstallError]: Collecting sudden-death@ git+https://github.com/dev-hato/sudden-death@ (from -r /tmp/pipenv-dne7vscx-requirements/pipenv-cvolrgp9-reqs.txt (line 21))
#36 73.30 [pipenv.exceptions.InstallError]: ERROR: The URL 'git+https://github.com/dev-hato/sudden-death@' has an empty revision (after @) which is not supported. Include a revision after @ or remove @ from the URL.
#36 73.30 ERROR: Couldn't install package: {}
#36 73.30  Package installation failed...
```

pipenvを2024.0.0にアップデートするとsudden-deathのインストールに失敗するようなので、この問題を解決できるまでpipenvのアップデート処理を削除します。