### PR TITLE
pipenvアップデート

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ WORKDIR /usr/src/app
 
 COPY .npmrc .npmrc
 COPY Pipfile Pipfile
+COPY Pipfile.lock Pipfile.lock
 COPY package.json package.json
 COPY package-lock.json package-lock.json
 
@@ -34,9 +35,9 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends nodejs && \
     pip install pipenv==2023.12.1 --no-cache-dir && \
     if [ "${ENV}" = 'dev' ]; then \
-      pipenv install --system --skip-lock --dev; \
+      pipenv install --system --dev; \
     else \
-      pipenv install --system --skip-lock; \
+      pipenv install --system; \
     fi && \
     npm install && \
     pip uninstall -y pipenv virtualenv && \

--- a/scripts/pr_format/pr_format/install_pipenv.sh
+++ b/scripts/pr_format/pr_format/install_pipenv.sh
@@ -11,3 +11,15 @@ else
 fi
 
 pip install "${package_name_with_version}"
+
+if [ -f ${file_name} ]; then
+	new_version="$(pip list --outdated | grep pipenv || true)"
+	new_version="$(echo -e "${new_version}" | awk '{print $3}')"
+	if [ -n "${new_version}" ]; then
+		PATTERN_BEFORE="${package_name}[^ ]+"
+		PATTERN_AFTER="${package_name}==${new_version}"
+		sed -i -E "s/${PATTERN_BEFORE}/${PATTERN_AFTER}/g" ${file_name}
+		pip install "${package_name}==${new_version}"
+		exit 1
+	fi
+fi


### PR DESCRIPTION
dev-hato/hato-bot#4030 をRevertします。
また、 https://github.com/pypa/pipenv/pull/6098 により `pipenv install` 実行時に `Pipfile.lock` が必要になっていそうなので、Dockerイメージに `Pipfile.lock` を含めます。