### PR TITLE
get_yahoo_geo_data: 曖昧な郵便番号指定対応

### DIFF
--- a/library/geo.py
+++ b/library/geo.py
@@ -34,7 +34,8 @@ def get_yahoo_geo_data(place: str) -> Optional[Dict[str, str]]:
     :param place: 地名・住所・郵便番号
     :return: place: 地名, lat: 緯度, lon: 経度
     """
-    is_zip_code = re.match(r"[0-9]{3}-[0-9]{4}", place)
+    # 曖昧な指定に対応できるよう、3桁以上で始まっているなら郵便番号としている
+    is_zip_code = re.match(r"^[0-9]{3}", place)
 
     if is_zip_code:
         url = "https://map.yahooapis.jp/search/zip/V1/zipCodeSearch"


### PR DESCRIPTION
身バレ防止等の目的で上三桁しかない曖昧な郵便番号 (例: 皇居 (〒100-0001) 周辺の意で `amesh 100` ) を指定するケースがあるようなので、このような場合も郵便番号として扱います。