### PR TITLE
asyncio周り修正

### DIFF
--- a/run.py
+++ b/run.py
@@ -233,7 +233,7 @@ def main():
                                             break
                                         except ReadTimeout as e:
                                             logger.exception(e)
-                                            time.sleep(1)
+                                            await asyncio.sleep(1)
 
                                     if cred is not None and cred["id"] in mentions:
                                         client = MisskeyClient(misskey_client, note)
@@ -248,7 +248,7 @@ def main():
                                             logger.exception(e)
                                             client.post("エラーが発生したっぽ......")
                 except websockets.ConnectionClosedError:
-                    time.sleep(1)
+                    await asyncio.sleep(1)
 
         while True:
             try:

--- a/run.py
+++ b/run.py
@@ -252,8 +252,7 @@ def main():
 
         while True:
             try:
-                asyncio.get_event_loop().run_until_complete(misskey_runner())
-                break
+                asyncio.run(misskey_runner())
             except websockets.exceptions.InvalidStatusCode as e:
                 if e.status_code == 502:
                     logger.exception(e)


### PR DESCRIPTION
https://docs.python.org/ja/3/library/asyncio-eventloop.html

>アプリケーション開発者は通常 [asyncio.run()](https://docs.python.org/ja/3/library/asyncio-runner.html#asyncio.run) のような高水準の ayncio 関数だけを利用し、ループオブジェクトを参照したり、ループオブジェクトのメソッドを呼び出したりすることはほとんどありません。

とのことなので、 `asyncio.get_event_loop().run_until_complete` の代わりに `asyncio.run` を使います。

また、非同期な関数内では `time.sleep` の代わりに `asyncio.sleep` を使います。