### PR TITLE
renovate: Pythonをアップデート対象から除外

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,8 @@
     "numpy",
     "click",
     "pandas",
-    "ghcr.io/astral-sh/uv"
+    "ghcr.io/astral-sh/uv",
+    "python"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/blob/38e0c65b7dce7bf5a0490bba276cba7a2853d86f/scripts/deploy_hato_bot/update_version_python_version/get_python_version.sh#L11
Pythonのバージョンは上記でDockerイメージと同期するので、renovateのアップデート対象からは除外します。