### PR TITLE
requests-mockからresponsesへ移行

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
 [dependency-groups]
 dev = [
   "autopep8==2.3.2",
-  "requests-mock==1.12.1",
+  "responses==0.26.3",
   "pylint==4.0.7",
   "sqlfluff==4.3.0",
   "mypy==2.1.0",

--- a/tests/library/test_geo.py
+++ b/tests/library/test_geo.py
@@ -25,14 +25,17 @@ def set_yahoo_mock(
         content = {}
 
     params = {"appid": conf.YAHOO_API_TOKEN, "query": place, "output": "json"}
-    query = "&".join([f"{k}={v}" for k, v in params.items()])
 
     if is_zip_code:
         url = "https://map.yahooapis.jp/search/zip/V1/zipCodeSearch"
     else:
         url = "https://map.yahooapis.jp/geocode/V1/geoCoder"
 
-    mocker.get(url + "?" + query, body=json.dumps(content).encode())
+    mocker.get(
+        url,
+        body=json.dumps(content).encode(),
+        match=[responses.matchers.query_param_matcher(params)],
+    )
 
 
 class TestGetYahooGeoData(unittest.TestCase):
@@ -103,8 +106,9 @@ def set_gsi_mock(place: str, mocker: responses.RequestsMock, content=None):
         content = {}
 
     mocker.get(
-        "https://msearch.gsi.go.jp/address-search/AddressSearch" + "?q=" + place,
+        "https://msearch.gsi.go.jp/address-search/AddressSearch",
         body=json.dumps(content).encode(),
+        match=[responses.matchers.query_param_matcher({"q": place})],
     )
 
 

--- a/tests/library/test_geo.py
+++ b/tests/library/test_geo.py
@@ -5,14 +5,14 @@ amesh.pyのテスト
 import json
 import unittest
 
-import requests_mock
+import responses
 
 import slackbot_settings as conf
 from library.geo import get_gsi_geo_data, get_yahoo_geo_data
 
 
 def set_yahoo_mock(
-    place: str, mocker: requests_mock.Mocker, is_zip_code: bool, content=None
+    place: str, mocker: responses.RequestsMock, is_zip_code: bool, content=None
 ):
     """
     Mockを設定する
@@ -32,7 +32,7 @@ def set_yahoo_mock(
     else:
         url = "https://map.yahooapis.jp/geocode/V1/geoCoder"
 
-    mocker.get(url + "?" + query, content=json.dumps(content).encode())
+    mocker.get(url + "?" + query, body=json.dumps(content).encode())
 
 
 class TestGetYahooGeoData(unittest.TestCase):
@@ -42,7 +42,7 @@ class TestGetYahooGeoData(unittest.TestCase):
 
     def test_valid_place(self):
         """正しい地名を指定した場合"""
-        with requests_mock.Mocker() as mocker:
+        with responses.RequestsMock(assert_all_requests_are_fired=False) as mocker:
             place = "長野"
             result = {
                 "place": "長野県長野市",
@@ -64,7 +64,7 @@ class TestGetYahooGeoData(unittest.TestCase):
 
     def test_valid_zip_code(self):
         """正しい郵便番号を指定した場合"""
-        with requests_mock.Mocker() as mocker:
+        with responses.RequestsMock(assert_all_requests_are_fired=False) as mocker:
             place = "380-8512"
             result = {
                 "place": "長野県長野市大字鶴賀緑町１６１３番地",
@@ -86,13 +86,13 @@ class TestGetYahooGeoData(unittest.TestCase):
 
     def test_invalid_place(self):
         """正しくない地名を指定した場合"""
-        with requests_mock.Mocker() as mocker:
+        with responses.RequestsMock(assert_all_requests_are_fired=False) as mocker:
             place = "hoge"
             set_yahoo_mock(place, mocker, False)
             self.assertIsNone(get_yahoo_geo_data(place))
 
 
-def set_gsi_mock(place: str, mocker: requests_mock.Mocker, content=None):
+def set_gsi_mock(place: str, mocker: responses.RequestsMock, content=None):
     """
     国土地理院用のMockを設定する
     :param place: 地名
@@ -104,7 +104,7 @@ def set_gsi_mock(place: str, mocker: requests_mock.Mocker, content=None):
 
     mocker.get(
         "https://msearch.gsi.go.jp/address-search/AddressSearch" + "?q=" + place,
-        content=json.dumps(content).encode(),
+        body=json.dumps(content).encode(),
     )
 
 
@@ -116,7 +116,7 @@ class TestGetGsiGeoData(unittest.TestCase):
     def test_valid_place(self):
         """完全一致のある地名を指定した場合"""
 
-        with requests_mock.Mocker() as mocker:
+        with responses.RequestsMock(assert_all_requests_are_fired=False) as mocker:
             place = "高ボッチ山"
             result = {
                 "place": "高ボッチ山",
@@ -179,7 +179,7 @@ class TestGetGsiGeoData(unittest.TestCase):
     def test_valid_full_width_place(self):
         """完全一致のある地名 (APIからの取得結果は全角) を指定した場合"""
 
-        with requests_mock.Mocker() as mocker:
+        with responses.RequestsMock(assert_all_requests_are_fired=False) as mocker:
             place = "岡谷JCT"
             result = {
                 "place": "岡谷JCT",
@@ -221,7 +221,7 @@ class TestGetGsiGeoData(unittest.TestCase):
 
     def test_invalid_place(self):
         """正しくない地名を指定した場合"""
-        with requests_mock.Mocker() as mocker:
+        with responses.RequestsMock(assert_all_requests_are_fired=False) as mocker:
             place = "hoge"
             set_gsi_mock(place, mocker)
             self.assertIsNone(get_gsi_geo_data(place))

--- a/tests/plugins/test_hato.py
+++ b/tests/plugins/test_hato.py
@@ -8,7 +8,7 @@ import re
 import unittest
 from typing import List
 
-import requests_mock
+import responses
 
 import slackbot_settings as conf
 from plugins.hato import (
@@ -64,7 +64,7 @@ class TestEarthQuake(unittest.TestCase):
     地震コマンドが正しく動作しているかテストする
     """
 
-    def get_earth_quake_test(self, mocker: requests_mock.Mocker):
+    def get_earth_quake_test(self, mocker: responses.RequestsMock):
         """
         地震情報を取得できるかテスト
         :param mocker requestsのMock
@@ -75,8 +75,8 @@ class TestEarthQuake(unittest.TestCase):
             os.path.join(os.path.dirname(__file__), "test.png"), mode="rb"
         ) as picture_file:
             mocker.get(
-                re.compile(r"tile\.openstreetmap\.org/.+\.png"),
-                content=picture_file.read(),
+                re.compile(r".*tile\.openstreetmap\.org/.+\.png"),
+                body=picture_file.read(),
             )
 
         with open(
@@ -84,14 +84,15 @@ class TestEarthQuake(unittest.TestCase):
         ) as json_file:
             mocker.get(
                 "https://api.p2pquake.net/v2/history?codes=551&limit=3",
-                content=json_file.read(),
+                body=json_file.read(),
+                content_type="application/json",
             )
 
         actual = earth_quake(client1)
         self.assertEqual(None, actual)
         return client1
 
-    def earth_quake_upload_png_test(self, mocker: requests_mock.Mocker, msg: str):
+    def earth_quake_upload_png_test(self, mocker: responses.RequestsMock, msg: str):
         """
         地震コマンドを実行し、png画像を「map.png」としてuploadできるかテスト
         :param mocker requestsのMock
@@ -105,7 +106,7 @@ class TestEarthQuake(unittest.TestCase):
         """
         引数なしで地震コマンドが実行できるかテスト
         """
-        with requests_mock.Mocker() as mocker:
+        with responses.RequestsMock(assert_all_requests_are_fired=False) as mocker:
             self.earth_quake_upload_png_test(
                 mocker,
                 "```\n"
@@ -124,7 +125,7 @@ class TestAmesh(unittest.TestCase):
 
     def get_amesh_test(
         self,
-        mocker: requests_mock.Mocker,
+        mocker: responses.RequestsMock,
         place: str,
     ):
         """
@@ -139,13 +140,17 @@ class TestAmesh(unittest.TestCase):
         ) as picture_file:
             image_content = picture_file.read()
             mocker.get(
-                re.compile(r"www\.jma\.go\.jp/bosai/jmatile/data/nowc/.+\.png"),
-                content=image_content,
+                re.compile(r".*www\.jma\.go\.jp/bosai/jmatile/data/nowc/.+\.png"),
+                body=image_content,
             )
             mocker.get(
-                re.compile(r"tile\.openstreetmap\.org/.+\.png"),
-                request_headers={"user-agent": f"hato-bot/{conf.VERSION}"},
-                content=image_content,
+                re.compile(r".*tile\.openstreetmap\.org/.+\.png"),
+                match=[
+                    responses.matchers.header_matcher(
+                        {"user-agent": f"hato-bot/{conf.VERSION}"}
+                    )
+                ],
+                body=image_content,
             )
 
         with open(
@@ -153,24 +158,32 @@ class TestAmesh(unittest.TestCase):
             mode="rb",
         ) as json_file:
             jma_json_url = re.compile(
-                r"www.jma.go.jp/bosai/jmatile/data/nowc/targetTimes_N\d.json"
+                r".*www.jma.go.jp/bosai/jmatile/data/nowc/targetTimes_N\d.json"
             )
-            mocker.get(jma_json_url, content=json_file.read())
+            mocker.get(
+                jma_json_url,
+                body=json_file.read(),
+                content_type="application/json",
+            )
 
         with open(
             os.path.join(os.path.dirname(__file__), "test_liden_data.geojson"),
             mode="rb",
         ) as liden_file:
             jma_liden_url = re.compile(
-                r"www.jma.go.jp/bosai/jmatile/data/nowc/.+/liden/data.geojson"
+                r".*www.jma.go.jp/bosai/jmatile/data/nowc/.+/liden/data.geojson"
             )
-            mocker.get(jma_liden_url, content=liden_file.read())
+            mocker.get(
+                jma_liden_url,
+                body=liden_file.read(),
+                content_type="application/json",
+            )
 
         actual = amesh(client1, place=place)
         self.assertEqual(None, actual)
         return client1
 
-    def amesh_upload_png_test(self, mocker: requests_mock.Mocker, place: str, msg: str):
+    def amesh_upload_png_test(self, mocker: responses.RequestsMock, place: str, msg: str):
         """
         ameshコマンドを実行し、png画像を「amesh.png」としてuploadできるかテスト
         :param mocker requestsのMock
@@ -185,7 +198,7 @@ class TestAmesh(unittest.TestCase):
         """
         引数なしでameshコマンドが実行できるかテスト
         """
-        with requests_mock.Mocker() as mocker:
+        with responses.RequestsMock(assert_all_requests_are_fired=False) as mocker:
             content = {
                 "Feature": [
                     {
@@ -203,7 +216,7 @@ class TestAmesh(unittest.TestCase):
         """
         引数ありでameshコマンドが実行できるかテスト
         """
-        with requests_mock.Mocker() as mocker:
+        with responses.RequestsMock(assert_all_requests_are_fired=False) as mocker:
             coordinate = ["12.345", "123.456"]
             self.amesh_upload_png_test(
                 mocker, " ".join(coordinate), "雨雲状況をお知らせするっぽ！"
@@ -215,7 +228,7 @@ class TestAmedas(unittest.TestCase):
     amedasが正しく動作しているかテストする
     """
 
-    def get_amedas_test(self, mocker: requests_mock.Mocker, place: str, msg: str):
+    def get_amedas_test(self, mocker: responses.RequestsMock, place: str, msg: str):
         """
         amedasを取得できるかテスト
         :param mocker requestsのMock
@@ -240,7 +253,11 @@ class TestAmedas(unittest.TestCase):
                 os.path.join(os.path.dirname(__file__), mock_data["file_name"]),
                 mode="rb",
             ) as mock_file:
-                mocker.get(mock_data["url"], content=mock_file.read())
+                mocker.get(
+                    mock_data["url"],
+                    body=mock_file.read(),
+                    content_type="application/json",
+                )
 
         client1 = TestClient()
         actual = amedas(client1, place=place)
@@ -251,7 +268,7 @@ class TestAmedas(unittest.TestCase):
         """
         引数なしでamedasコマンドが実行できるかテスト
         """
-        with requests_mock.Mocker() as mocker:
+        with responses.RequestsMock(assert_all_requests_are_fired=False) as mocker:
             content = {
                 "Feature": [
                     {
@@ -278,7 +295,7 @@ class TestAmedas(unittest.TestCase):
         """
         引数ありでamedasコマンドが実行できるかテスト
         """
-        with requests_mock.Mocker() as mocker:
+        with responses.RequestsMock(assert_all_requests_are_fired=False) as mocker:
             coordinate = ["35.64657460", "139.65324950"]
             self.get_amedas_test(
                 mocker,
@@ -301,7 +318,7 @@ class TestAltitude(unittest.TestCase):
 
     def altitude_test(
         self,
-        mocker: requests_mock.Mocker,
+        mocker: responses.RequestsMock,
         place: str,
         coordinates: List[str],
         content=None,
@@ -322,7 +339,7 @@ class TestAltitude(unittest.TestCase):
         query = "&".join([f"{k}={v}" for k, v in params.items()])
         mocker.get(
             "https://map.yahooapis.jp/alt/V1/getAltitude?" + query,
-            content=json.dumps(content).encode(),
+            body=json.dumps(content).encode(),
         )
         # pylint: disable=E1121
         actual = altitude(client1, place)
@@ -333,7 +350,7 @@ class TestAltitude(unittest.TestCase):
         """
         引数なしでaltitudeコマンドが実行できるかテスト
         """
-        with requests_mock.Mocker() as mocker:
+        with responses.RequestsMock(assert_all_requests_are_fired=False) as mocker:
             coordinates = ["35.64657460", "139.65324950"]
             geo_content = {
                 "Feature": [
@@ -358,7 +375,7 @@ class TestAltitude(unittest.TestCase):
         """
         引数ありでaltitudeコマンドが実行できるかテスト
         """
-        with requests_mock.Mocker() as mocker:
+        with responses.RequestsMock(assert_all_requests_are_fired=False) as mocker:
             coordinates = ["12.345", "123.456"]
             altitude_ = 122
             altitude_content = {"Feature": [{"Property": {"Altitude": altitude_}}]}

--- a/tests/plugins/test_hato.py
+++ b/tests/plugins/test_hato.py
@@ -158,7 +158,7 @@ class TestAmesh(unittest.TestCase):
             mode="rb",
         ) as json_file:
             jma_json_url = re.compile(
-                r".*www.jma.go.jp/bosai/jmatile/data/nowc/targetTimes_N\d.json"
+                r".*www\.jma\.go\.jp/bosai/jmatile/data/nowc/targetTimes_N\d\.json"
             )
             mocker.get(
                 jma_json_url,
@@ -171,7 +171,7 @@ class TestAmesh(unittest.TestCase):
             mode="rb",
         ) as liden_file:
             jma_liden_url = re.compile(
-                r".*www.jma.go.jp/bosai/jmatile/data/nowc/.+/liden/data.geojson"
+                r".*www\.jma\.go\.jp/bosai/jmatile/data/nowc/.+/liden/data\.geojson"
             )
             mocker.get(
                 jma_liden_url,

--- a/tests/plugins/test_hato.py
+++ b/tests/plugins/test_hato.py
@@ -336,10 +336,10 @@ class TestAltitude(unittest.TestCase):
             "coordinates": ",".join(reversed(coordinates)),
             "output": "json",
         }
-        query = "&".join([f"{k}={v}" for k, v in params.items()])
         mocker.get(
-            "https://map.yahooapis.jp/alt/V1/getAltitude?" + query,
+            "https://map.yahooapis.jp/alt/V1/getAltitude",
             body=json.dumps(content).encode(),
+            match=[responses.matchers.query_param_matcher(params)],
         )
         # pylint: disable=E1121
         actual = altitude(client1, place)

--- a/tests/plugins/test_hato.py
+++ b/tests/plugins/test_hato.py
@@ -183,7 +183,9 @@ class TestAmesh(unittest.TestCase):
         self.assertEqual(None, actual)
         return client1
 
-    def amesh_upload_png_test(self, mocker: responses.RequestsMock, place: str, msg: str):
+    def amesh_upload_png_test(
+        self, mocker: responses.RequestsMock, place: str, msg: str
+    ):
         """
         ameshコマンドを実行し、png画像を「amesh.png」としてuploadできるかテスト
         :param mocker requestsのMock

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ dev = [
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pylint" },
-    { name = "requests-mock" },
+    { name = "responses" },
     { name = "sqlfluff" },
     { name = "tomlkit" },
 ]
@@ -676,7 +676,7 @@ dev = [
     { name = "mypy", specifier = "==2.1.0" },
     { name = "pre-commit", specifier = "==4.6.2" },
     { name = "pylint", specifier = "==4.0.7" },
-    { name = "requests-mock", specifier = "==1.12.1" },
+    { name = "responses", specifier = "==0.26.3" },
     { name = "sqlfluff", specifier = "==4.3.0" },
     { name = "tomlkit", specifier = "==0.15.1" },
 ]
@@ -1563,15 +1563,17 @@ wheels = [
 ]
 
 [[package]]
-name = "requests-mock"
-version = "1.12.1"
+name = "responses"
+version = "0.26.3"
 source = { registry = "https://pypi.flatt.tech/simple/" }
 dependencies = [
+    { name = "pyyaml" },
     { name = "requests" },
+    { name = "urllib3" },
 ]
-sdist = { url = "https://pypi.flatt.tech/files/packages/92/32/587625f91f9a0a3d84688bf9cfc4b2480a7e8ec327cefd0ff2ac891fd2cf/requests-mock-1.12.1.tar.gz", hash = "sha256:e9e12e333b525156e82a3c852f22016b9158220d2f47454de9cae8a77d371401", size = 60901, upload-time = "2024-03-29T03:54:29.446Z" }
+sdist = { url = "https://pypi.flatt.tech/files/packages/9f/47/f216a33221db8eff328987661cf18371afee89c62a62b434b963d6b509c9/responses-0.26.3.tar.gz", hash = "sha256:b0c11ca8131b8b227b8d5108e6ed39772222bd5aab030ed430e8f99057c4c409", size = 86335, upload-time = "2026-08-26T19:17:24.373Z" }
 wheels = [
-    { url = "https://pypi.flatt.tech/files/packages/97/ec/889fbc557727da0c34a33850950310240f2040f3b1955175fdb2b36a8910/requests_mock-1.12.1-py2.py3-none-any.whl", hash = "sha256:b1e37054004cdd5e56c84454cc7df12b25f90f382159087f4b6915aaeef39563", size = 27695, upload-time = "2024-03-29T03:54:27.64Z" },
+    { url = "https://pypi.flatt.tech/files/packages/6d/86/ca7958de70cb0752350575e98229368a3a2f746a2942034b3364e17312bb/responses-0.26.3-py3-none-any.whl", hash = "sha256:74474f799334ac4f37d93b6437ecc3bb1bb5c77a8d31780a338643be2dce0af8", size = 36289, upload-time = "2026-08-26T19:17:23.176Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
2年以上更新のない `requests-mock==1.12.1` を、活発にメンテナンスされている `responses==0.26.3` へ置き換えます。

## 背景

- `requests-mock` の最新リリースは 2024-03 で、約2年半更新がありません
- `responses`（Sentry がメンテナンス）は 2026-08 にもリリースがあり、活発に保守されています

## 変更内容

- `pyproject.toml` / `uv.lock`: `requests-mock==1.12.1` → `responses==0.26.3`
- テストのモックを `responses` へ移行
  - `requests_mock.Mocker()` → `responses.RequestsMock(assert_all_requests_are_fired=False)`（`requests-mock` は未発火モックを検証しないため挙動を合わせる）
  - キーワード引数 `content=` → `body=`
  - 型注釈 `requests_mock.Mocker` → `responses.RequestsMock`
- クエリ文字列付きURLの手組みをやめ、`responses.matchers.query_param_matcher` でクエリパラメータを照合
  （`test_geo.py` の Yahoo / 国土地理院、`test_hato.py` の altitude）
- 画像タイル等の正規表現URLは先頭に `.*` を付与（`responses` は `re.match` で前方一致のため）し、
  ドメイン部を含むリテラルのドットを `\.` へエスケープ
- JSON を返すファイルベースのモックに `content_type="application/json"` を付与
  （`responses` の既定 `text/plain` だと `requests` が ISO-8859-1 で解釈し、日本語が文字化けするため）
- User-Agent ヘッダーの照合を `request_headers=` から `responses.matchers.header_matcher` へ置換