### PR TITLE
autopep8をblackに置き換える

### DIFF
--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -49,7 +49,7 @@ jobs:
           client-id: ${{ secrets.PROJECT_AUTOMATION_APP_CLIENT_ID }}
           private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }}
       # formatする
-      # --exit-codeをつけることで、autopep8内でエラーが起きれば1、差分があれば2のエラーステータスコードが返ってくる。正常時は0が返る
+      # blackとisortでformatをかけ、トラッキング対象のファイルに差分があればformat.sh内のgit diff --exit-codeで終了コード1を返す。正常時は0が返る
       - name: Format files
         id: format
         if: github.event_name != 'pull_request' || github.event.action != 'closed'

--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -49,7 +49,6 @@ jobs:
           client-id: ${{ secrets.PROJECT_AUTOMATION_APP_CLIENT_ID }}
           private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }}
       # formatする
-      # blackとisortでformatをかけ、トラッキング対象のファイルに差分があればformat.sh内のgit diff --exit-codeで終了コード1を返す。正常時は0が返る
       - name: Format files
         id: format
         if: github.event_name != 'pull_request' || github.event.action != 'closed'

--- a/.pep8
+++ b/.pep8
@@ -1,2 +1,0 @@
-[pycodestyle]
-ignore = E203

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ uv tool run pre-commit install
 
 #### 補足
 
-- コードを整形する場合は`uv tool run autopep8 --in-place --recursive .`を実行します。
+- コードを整形する場合は`uv tool run black .`を実行します。
 
 ## 鳩botコマンド一覧
 

--- a/README.template.md
+++ b/README.template.md
@@ -151,7 +151,7 @@ uv tool run pre-commit install
 
 #### 補足
 
-- コードを整形する場合は`uv tool run autopep8 --in-place --recursive .`を実行します。
+- コードを整形する場合は`uv tool run black .`を実行します。
 
 ## 鳩botコマンド一覧
 

--- a/plugins/hato.py
+++ b/plugins/hato.py
@@ -443,7 +443,7 @@ def version():
         try:
             repo = Repo()
             str_ver += f" (Commit {repo.head.commit.hexsha[:7]})"
-        except (InvalidGitRepositoryError, GitCommandNotFound):
+        except InvalidGitRepositoryError, GitCommandNotFound:
             pass
 
     str_ver += (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
-  "autopep8==2.3.2",
+  "black==26.5.1",
   "responses==0.26.3",
   "pylint==4.0.7",
   "sqlfluff==4.3.0",

--- a/scripts/pr_format/pr_format/fix_pyproject.py
+++ b/scripts/pr_format/pr_format/fix_pyproject.py
@@ -86,7 +86,7 @@ def is_std_or_local_lib(project_root: Path, package_name: str) -> bool:
     for finder in sys.meta_path:
         try:
             package_spec = finder.find_spec(package_name, ".")
-        except (AttributeError, ValueError, ModuleNotFoundError):
+        except AttributeError, ValueError, ModuleNotFoundError:
             pass
 
         if package_spec:
@@ -95,7 +95,7 @@ def is_std_or_local_lib(project_root: Path, package_name: str) -> bool:
     if package_spec is None:
         try:
             package_spec = importlib.util.find_spec(package_name)
-        except (AttributeError, ValueError, ModuleNotFoundError):
+        except AttributeError, ValueError, ModuleNotFoundError:
             pass
 
     # パッケージ情報がないならばpyproject.tomlによってインストールされたものと判定する

--- a/scripts/pr_format/pr_format/format.sh
+++ b/scripts/pr_format/pr_format/format.sh
@@ -11,5 +11,5 @@ if [ "$(yq .tool.uv.sources.sudden-death.git pyproject.toml)" != 'null' ]; then
 	uv lock --upgrade-package sudden-death
 fi
 
-uv tool run autopep8 --exit-code --in-place --recursive .
+uv tool run black .
 uv tool run isort --sp .isort.cfg .

--- a/uv.lock
+++ b/uv.lock
@@ -224,15 +224,25 @@ wheels = [
 ]
 
 [[package]]
-name = "autopep8"
-version = "2.3.2"
+name = "black"
+version = "26.5.1"
 source = { registry = "https://pypi.flatt.tech/simple/" }
 dependencies = [
-    { name = "pycodestyle" },
+    { name = "click" },
+    { name = "mypy-extensions" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "platformdirs" },
+    { name = "pytokens" },
 ]
-sdist = { url = "https://pypi.flatt.tech/files/packages/50/d8/30873d2b7b57dee9263e53d142da044c4600a46f2d28374b3e38b023df16/autopep8-2.3.2.tar.gz", hash = "sha256:89440a4f969197b69a995e4ce0661b031f455a9f776d2c5ba3dbd83466931758", size = 92210, upload-time = "2025-01-14T14:46:18.454Z" }
+sdist = { url = "https://pypi.flatt.tech/files/packages/c0/37/5628dd55bf2b34257fc7603f0fe97c40e3aaf24265f416a9c85c95ca1436/black-26.5.1.tar.gz", hash = "sha256:dd321f668053961824bcc1be1cc1df748b2d7e4fa28086b08331e577b0100a73", size = 679439, upload-time = "2026-05-18T16:53:36.107Z" }
 wheels = [
-    { url = "https://pypi.flatt.tech/files/packages/9e/43/53afb8ba17218f19b77c7834128566c5bbb100a0ad9ba2e8e89d089d7079/autopep8-2.3.2-py2.py3-none-any.whl", hash = "sha256:ce8ad498672c845a0c3de2629c15b635ec2b05ef8177a6e7c91c74f3e9b51128", size = 45807, upload-time = "2025-01-14T14:46:15.466Z" },
+    { url = "https://pypi.flatt.tech/files/packages/a6/16/a8da8eb208c51c7f4ce74609a45d0dcc6d8a2141e45e81ee5289d1bb0d59/black-26.5.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:e88976690a64b0af98312ca958415849cb42423423c5f2ee74af4b49a97a2168", size = 2004800, upload-time = "2026-05-18T17:05:38.182Z" },
+    { url = "https://pypi.flatt.tech/files/packages/11/8a/a479296a19e383b70a725882a6cf3d786540601ff03cabbaaf1cce864c5a/black-26.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:32d5ea7f6c8bdfa6e648326ebca1f02b0764e2a029edc6f8dce2627e19d468c3", size = 1815576, upload-time = "2026-05-18T17:05:40.309Z" },
+    { url = "https://pypi.flatt.tech/files/packages/81/6b/cfaf3d39f25132c156a068f6b805576c9103a84086019507c70e1911ee7d/black-26.5.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ea8d16dc41655aa113cd64665e7219446cd7e4ff2248d7178eaa905190c86b18", size = 1877927, upload-time = "2026-05-18T17:05:42.463Z" },
+    { url = "https://pypi.flatt.tech/files/packages/66/76/302e313964bcff7e28df329d39f84f5270095730d85ff0acc260610a0d82/black-26.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:577f21094ea469ef92ec1adaf2c9441a226d2144d01a5be2fa823cecf6543e50", size = 1511860, upload-time = "2026-05-18T17:05:43.943Z" },
+    { url = "https://pypi.flatt.tech/files/packages/27/4e/a3827e35e0e567f9f9ee59e2a0ab979267dca98718f25547ca8c6733afd4/black-26.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:ed1a20af114c301a0269bf01163d51dbef72737fd65f850001e7cbe7f3c7abae", size = 1316632, upload-time = "2026-05-18T17:05:45.521Z" },
+    { url = "https://pypi.flatt.tech/files/packages/94/51/f975cae76d44274cc2868dc9040ac5d58d464784610234455b4e7b19c6ef/black-26.5.1-py3-none-any.whl", hash = "sha256:4ed7f7da04046d2e488437170797d3b4a4ad83906683bcb7dfc68b673bbce5e2", size = 213693, upload-time = "2026-05-18T16:53:33.964Z" },
 ]
 
 [[package]]
@@ -630,7 +640,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "autopep8" },
+    { name = "black" },
     { name = "flake8" },
     { name = "importlib-metadata" },
     { name = "isort" },
@@ -669,7 +679,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "autopep8", specifier = "==2.3.2" },
+    { name = "black", specifier = "==26.5.1" },
     { name = "flake8", specifier = "==7.3.0" },
     { name = "importlib-metadata", specifier = "==9.0.0" },
     { name = "isort", specifier = "==8.0.1" },
@@ -1470,6 +1480,25 @@ source = { registry = "https://pypi.flatt.tech/simple/" }
 sdist = { url = "https://pypi.flatt.tech/files/packages/6a/53/ed9d74092561d4b01a2ef1349d52cdbc135e526c245f366b089cfca6de49/python_dotenv-1.2.3.tar.gz", hash = "sha256:a20a594dabeaa385725aa239d5244871c143ecb356add8a20fcf23773a6c3a35", size = 58945, upload-time = "2026-08-16T16:54:54.067Z" }
 wheels = [
     { url = "https://pypi.flatt.tech/files/packages/0d/17/c5c6b53ddc18f297992099b3d9ec16c855c0ccc83263a21fe4d1c625ec6c/python_dotenv-1.2.3-py3-none-any.whl", hash = "sha256:904552145e8bfed22162c09dab1c2b9b54fefa7b23ba780f4f26ca0316b0f0d9", size = 22780, upload-time = "2026-08-16T16:54:52.473Z" },
+]
+
+[[package]]
+name = "pytokens"
+version = "0.4.1"
+source = { registry = "https://pypi.flatt.tech/simple/" }
+sdist = { url = "https://pypi.flatt.tech/files/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015, upload-time = "2026-01-30T01:03:45.924Z" }
+wheels = [
+    { url = "https://pypi.flatt.tech/files/packages/8f/a7/b470f672e6fc5fee0a01d9e75005a0e617e162381974213a945fcd274843/pytokens-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4a14d5f5fc78ce85e426aa159489e2d5961acf0e47575e08f35584009178e321", size = 160821, upload-time = "2026-01-30T01:03:19.684Z" },
+    { url = "https://pypi.flatt.tech/files/packages/80/98/e83a36fe8d170c911f864bfded690d2542bfcfacb9c649d11a9e6eb9dc41/pytokens-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f50fd18543be72da51dd505e2ed20d2228c74e0464e4262e4899797803d7fa", size = 254263, upload-time = "2026-01-30T01:03:20.834Z" },
+    { url = "https://pypi.flatt.tech/files/packages/0f/95/70d7041273890f9f97a24234c00b746e8da86df462620194cef1d411ddeb/pytokens-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc74c035f9bfca0255c1af77ddd2d6ae8419012805453e4b0e7513e17904545d", size = 268071, upload-time = "2026-01-30T01:03:21.888Z" },
+    { url = "https://pypi.flatt.tech/files/packages/da/79/76e6d09ae19c99404656d7db9c35dfd20f2086f3eb6ecb496b5b31163bad/pytokens-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f66a6bbe741bd431f6d741e617e0f39ec7257ca1f89089593479347cc4d13324", size = 271716, upload-time = "2026-01-30T01:03:23.633Z" },
+    { url = "https://pypi.flatt.tech/files/packages/79/37/482e55fa1602e0a7ff012661d8c946bafdc05e480ea5a32f4f7e336d4aa9/pytokens-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:b35d7e5ad269804f6697727702da3c517bb8a5228afa450ab0fa787732055fc9", size = 104539, upload-time = "2026-01-30T01:03:24.788Z" },
+    { url = "https://pypi.flatt.tech/files/packages/30/e8/20e7db907c23f3d63b0be3b8a4fd1927f6da2395f5bcc7f72242bb963dfe/pytokens-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8fcb9ba3709ff77e77f1c7022ff11d13553f3c30299a9fe246a166903e9091eb", size = 168474, upload-time = "2026-01-30T01:03:26.428Z" },
+    { url = "https://pypi.flatt.tech/files/packages/d6/81/88a95ee9fafdd8f5f3452107748fd04c24930d500b9aba9738f3ade642cc/pytokens-0.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79fc6b8699564e1f9b521582c35435f1bd32dd06822322ec44afdeba666d8cb3", size = 290473, upload-time = "2026-01-30T01:03:27.415Z" },
+    { url = "https://pypi.flatt.tech/files/packages/cf/35/3aa899645e29b6375b4aed9f8d21df219e7c958c4c186b465e42ee0a06bf/pytokens-0.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d31b97b3de0f61571a124a00ffe9a81fb9939146c122c11060725bd5aea79975", size = 303485, upload-time = "2026-01-30T01:03:28.558Z" },
+    { url = "https://pypi.flatt.tech/files/packages/52/a0/07907b6ff512674d9b201859f7d212298c44933633c946703a20c25e9d81/pytokens-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:967cf6e3fd4adf7de8fc73cd3043754ae79c36475c1c11d514fc72cf5490094a", size = 306698, upload-time = "2026-01-30T01:03:29.653Z" },
+    { url = "https://pypi.flatt.tech/files/packages/39/2a/cbbf9250020a4a8dd53ba83a46c097b69e5eb49dd14e708f496f548c6612/pytokens-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:584c80c24b078eec1e227079d56dc22ff755e0ba8654d8383b2c549107528918", size = 116287, upload-time = "2026-01-30T01:03:30.912Z" },
+    { url = "https://pypi.flatt.tech/files/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", size = 13729, upload-time = "2026-01-30T01:03:45.029Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
autopep8はしばらくリリースされていないため、フォーマッタをblackに変更します。

- 開発依存を autopep8==2.3.2 から black==26.5.1 へ
- format.sh を black 実行に変更
- README の整形コマンド案内を black に更新
- autopep8 専用の .pep8 を削除 (.flake8 の E203 除外は残す)